### PR TITLE
Store request authorization in response properties.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<c:changelog project="org.thepalaceproject.http" xmlns:c="urn:com.io7m.changelog:4.0">
+  <c:releases>
+    <c:release date="2022-05-13T00:12:58+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.0">
+      <c:changes>
+        <c:change date="2022-05-13T00:12:58+00:00" summary="Added request authorization to response properties."/>
+      </c:changes>
+    </c:release>
+  </c:releases>
+  <c:ticket-systems>
+    <c:ticket-system default="true" id="org.nypl.jira" url="https://jira.nypl.org/browse/"/>
+  </c:ticket-systems>
+</c:changelog>

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseProperties.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseProperties.kt
@@ -54,7 +54,14 @@ data class LSHTTPResponseProperties(
    * The cookies returned
    */
 
-  val cookies: List<LSHTTPCookie>
+  val cookies: List<LSHTTPCookie>,
+
+  /**
+   * The authorization used to complete the request, if any. This may be a Simplified bearer token
+   * that was transparently negotiated by the client.
+   */
+
+  val authorization: LSHTTPAuthorizationType? = null
 ) {
 
   /**

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
@@ -73,6 +73,7 @@ abstract class LSHTTPBearerTokenContract {
     request.execute().use { response ->
       val status = response.status as LSHTTPResponseStatus.Responded.OK
       Assertions.assertEquals("text/html", status.properties.contentType.fullType)
+      Assertions.assertEquals(null, status.properties.authorization)
     }
   }
 
@@ -113,6 +114,7 @@ abstract class LSHTTPBearerTokenContract {
     request.execute().use { response ->
       val status = response.status as LSHTTPResponseStatus.Responded.OK
       Assertions.assertEquals(200, status.properties.status)
+      Assertions.assertEquals("Bearer abcd", status.properties.authorization?.toHeaderValue())
       Assertions.assertEquals("OK!", String(status.bodyStream!!.readBytes()))
     }
 
@@ -167,6 +169,7 @@ abstract class LSHTTPBearerTokenContract {
     request.execute().use { response ->
       val status = response.status as LSHTTPResponseStatus.Responded.OK
       Assertions.assertEquals(200, status.properties.status)
+      Assertions.assertEquals("Bearer abcd", status.properties.authorization?.toHeaderValue())
       Assertions.assertEquals("OK!", String(status.bodyStream!!.readBytes()))
     }
 
@@ -224,6 +227,7 @@ abstract class LSHTTPBearerTokenContract {
     request.execute().use { response ->
       val status = response.status as LSHTTPResponseStatus.Responded.Error
       Assertions.assertEquals(499, status.properties.status)
+      Assertions.assertEquals(null, status.properties.authorization)
       Assertions.assertTrue(status.properties.message.contains("Bearer token interceptor (LSHTTPBearerTokenInterceptor) parser failed"))
     }
 
@@ -249,6 +253,7 @@ abstract class LSHTTPBearerTokenContract {
       val status = response.status as LSHTTPResponseStatus.Responded.OK
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals("application/epub+zip", status.properties.contentType.fullType)
+      Assertions.assertEquals(null, status.properties.authorization)
       Assertions.assertTrue(status.properties.contentLength ?: 0L >= 270000L)
     }
   }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
@@ -12,6 +12,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.librarysimplified.http.api.LSHTTPCookie
 import org.librarysimplified.http.api.LSHTTPProblemReport
 import org.librarysimplified.http.api.LSHTTPProblemReportParserType
+import org.librarysimplified.http.api.LSHTTPRequestProperties
 import org.librarysimplified.http.api.LSHTTPResponseProperties
 import org.librarysimplified.http.api.LSHTTPResponseStatus
 import org.librarysimplified.http.api.LSHTTPResponseType
@@ -84,7 +85,8 @@ class LSHTTPResponse(
           problemReport = problemReport,
           message = responseMessage,
           headers = response.headers.toMultimap(),
-          cookies = cookies
+          cookies = cookies,
+          authorization = request.tag(LSHTTPRequestProperties::class.java)?.authorization
         )
 
       return when {


### PR DESCRIPTION
**What's this do?**

This stores the authorization used to perform an HTTP request in the properties of the response, so it is accessible to the caller.

**Why are we doing this? (w/ JIRA link if applicable)**

The HTTP client transparently handles bearer token negotiation: When a request to the CM returns a token document, the document is automatically parsed, the token is extracted, and the request is automatically retried using bearer authorization, all without informing the caller. However, there are situations where the caller may need to know that a token was returned, and where the caller needs to have access to that token for future requests. This enables the caller to examine the response properties, and retrieve the authorization that was used for the request; when a bearer token was returned by the CM, the `authorization` property contains that token.

This is required to support downloads of BiblioBoard audiobooks. The download of the manifest uses a bearer token negotiation. The caller needs to access that negotiated bearer token, in order to use it to download audio files in the future.

Notion: https://www.notion.so/lyrasis/Android-Error-downloading-BiblioBoard-audiobooks-03094266f26743fcb31f00b1de176b95

**How should this be tested? / Do these changes have associated tests?**

Unit tests are included. This can't be tested independently in the app, but when other PRs are complete, BiblioBoard audio books should play successfully.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran some downloads.