### PR TITLE
Target Android 13 (API 33).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -6,9 +6,10 @@
         <c:change date="2022-05-13T00:00:00+00:00" summary="Added request authorization to response properties."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-20T05:59:01+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.1">
+    <c:release date="2022-10-27T17:15:02+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.1">
       <c:changes>
-        <c:change date="2022-10-20T05:59:01+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-27T17:15:02+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ plugins {
 }
 
 ext {
-  androidBuildToolsVersion = "32.0.0"
-  androidCompileSDKVersion = 32
+  androidBuildToolsVersion = "33.0.0"
+  androidCompileSDKVersion = 33
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 32
+  androidTargetSDKVersion = 33
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")


### PR DESCRIPTION
What's this do?

This updates the app to target Android 13 (API 33).

Why are we doing this? (w/ JIRA link if applicable)

Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

How should this be tested? / Do these changes have associated tests?

Books and audiobooks of various kinds (including SAML downloads) should work.

Dependencies for merging? Releasing to production?

None.

Have you updated the changelog?

Yes

Has the application documentation been updated for these changes?

n/a

Did someone actually run this code to verify it works?

@ray-lee tested some downloads.
