### PR TITLE
Fixed bug of bearer token being incorrectly sent in some requests

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -6,10 +6,11 @@
         <c:change date="2022-05-13T00:00:00+00:00" summary="Added request authorization to response properties."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-27T17:15:02+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.1">
+    <c:release date="2022-11-07T16:09:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.1">
       <c:changes>
         <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
-        <c:change date="2022-10-27T17:15:02+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-11-07T16:09:45+00:00" summary="Fixed redirecting bearer token bug."/>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
This PR adds logic to handle when there's an unsuccessful response after a redirect. When downloading a book, there might be some redirection but there are some hosts (AWS, for instance) that don't require a bearer token because they'll handle the authorization header themselves. However, the bearer token is only being removed when the response detects a redirection, but there are some other cases where an error is returned instead of a "redirecting response code" and this logic handles these cases.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-Investigate-Biblioboard-Titles-not-downloading-for-Columbia-when-they-work-for-iOS-e0bf449fd44941f0b381da837e7dcb8a) saying that some Columbia Titles are not working for Android while they work for iOS.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "Columbia University Libraries" library
Search for "Rise of Marine Mammals and Green Alternatives" or "National Energy Strategy"
Confirm the title is successfully downloaded and can be read

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Did someone actually run this code to verify it works?**
Tested by @nunommts 