### PR TITLE
Downgrade to produce JDK 11 bytecode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*.kt]
 indent_size = 2
 insert_final_newline = true
+ktlint_standard_package-name = disabled
 
 [*.gradle]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 [*.kt]
 indent_size = 2
 insert_final_newline = true
-disabled_rules = import-ordering
 
 [*.gradle]
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ overdrive.json
 # backup files
 *~
 .ci/*.log
+
+scando.jar
+ktlint.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -452,7 +452,7 @@ allprojects {
             val kotlin: KotlinAndroidProjectExtension =
                 this.extensions["kotlin"] as KotlinAndroidProjectExtension
 
-            kotlin.jvmToolchain(17)
+            kotlin.jvmToolchain(11)
 
             /*
              * Configure the various required Android properties.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -473,10 +473,14 @@ allprojects {
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
 
+            /*
+             * Produce JDK 11 bytecode.
+             */
+
             android.compileOptions {
                 encoding = "UTF-8"
-                sourceCompatibility = JavaVersion.VERSION_17
-                targetCompatibility = JavaVersion.VERSION_17
+                sourceCompatibility = JavaVersion.VERSION_11
+                targetCompatibility = JavaVersion.VERSION_11
             }
 
             android.testOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,9 @@ val palaceRootBuildDirectory =
 val palaceDeployDirectory =
     "$palaceRootBuildDirectory/maven"
 val palaceScandoJarFile =
-    "$palaceRootBuildDirectory/scando.jar"
+    "$rootDir/scando.jar"
+val palaceKtlintJarFile =
+    "$rootDir/ktlint.jar"
 
 /**
  * Convenience functions to read strongly-typed values from property files.
@@ -98,7 +100,7 @@ fun configurePublishingFor(project: Project) {
         property(project, "POM_PACKAGING")
 
     val publishSources =
-        propertyBoolean(project, "org.thepalaceproject.publishSources")
+        propertyBoolean(project, "org.thepalaceproject.build.publishSources")
 
     /*
      * Create an empty JavaDoc jar. Required for Maven Central deployments.
@@ -192,7 +194,7 @@ fun configurePublishingFor(project: Project) {
      */
 
     if (!publishSources) {
-        logger.info("org.thepalaceproject.publishSources is false, so source jars are disabled.")
+        logger.info("org.thepalaceproject.build.publishSources is false, so source jars are disabled.")
 
         val taskSourcesEmpty =
             project.task("SourcesEmptyJar", org.gradle.jvm.tasks.Jar::class) {
@@ -229,7 +231,7 @@ fun createScandoDownloadTask(project: Project): Task {
     val scandoSHA256 =
         "08fba5fc4bc3b5a49d205a4c38356dc8c7e01f4963adb661b67f9d2ed23751ae"
     val scandoSource =
-        "https://repo1.maven.org/maven2/com/io7m/scando/com.io7m.scando.cmdline/${scandoVersion}/com.io7m.scando.cmdline-${scandoVersion}-main.jar"
+        "https://repo1.maven.org/maven2/com/io7m/scando/com.io7m.scando.cmdline/$scandoVersion/com.io7m.scando.cmdline-$scandoVersion-main.jar"
 
     val scandoMakeDirectory =
         project.task("ScandoMakeDirectory") {
@@ -269,9 +271,9 @@ fun createScandoAnalyzeTask(project: Project): Task {
     val oldGroup =
         group.replace('.', '/')
     val oldPath =
-        "${oldGroup}/${artifactId}/${versionPrevious}/${artifactId}-${versionPrevious}.aar"
+        "$oldGroup/$artifactId/$versionPrevious/$artifactId-$versionPrevious.aar"
     val oldUrl =
-        "https://repo1.maven.org/maven2/${oldPath}"
+        "https://repo1.maven.org/maven2/$oldPath"
 
     val commandLineArguments: List<String> = arrayListOf(
         "java",
@@ -285,7 +287,7 @@ fun createScandoAnalyzeTask(project: Project): Task {
         versionPrevious,
         "--ignoreMissingOld",
         "--newJar",
-        "${project.buildDir}/outputs/aar/${artifactId}-debug.aar",
+        "${project.buildDir}/outputs/aar/$artifactId-debug.aar",
         "--newJarVersion",
         versionCurrent,
         "--textReport",
@@ -310,14 +312,92 @@ rootProject.afterEvaluate {
     scandoDownloadTask = createScandoDownloadTask(this)
 }
 
+/**
+ * A function to download and verify the ktlint jar file.
+ *
+ * @return The verification task
+ */
+
+fun createKtlintDownloadTask(project: Project): Task {
+    val ktlintVersion =
+        "0.50.0"
+    val ktlintSHA256 =
+        "c704fbc28305bb472511a1e98a7e0b014aa13378a571b716bbcf9d99d59a5092"
+    val ktlintSource =
+        "https://repo1.maven.org/maven2/com/pinterest/ktlint/$ktlintVersion/ktlint-$ktlintVersion-all.jar"
+
+    val ktlintMakeDirectory =
+        project.task("KtlintMakeDirectory") {
+            mkdir(palaceRootBuildDirectory)
+        }
+
+    val ktlintDownload =
+        project.task("KtlintDownload", Download::class) {
+            src(ktlintSource)
+            dest(file(palaceKtlintJarFile))
+            overwrite(true)
+            onlyIfModified(true)
+            this.dependsOn.add(ktlintMakeDirectory)
+        }
+
+    return project.task("KtlintDownloadVerify", Verify::class) {
+        src(file(palaceKtlintJarFile))
+        checksum(ktlintSHA256)
+        algorithm("SHA-256")
+        this.dependsOn(ktlintDownload)
+    }
+}
+
+/**
+ * A task to execute ktlint to analyze semantic versioning.
+ */
+
+fun createKtlintCheckTask(project: Project): Task {
+    val commandLineArguments: List<String> = arrayListOf(
+        "java",
+        "-jar",
+        palaceKtlintJarFile,
+        "*/src/**/*.kt",
+        "*/build.gradle.kts",
+        "build.gradle.kts",
+        "!*/src/test/**"
+    )
+
+    return project.task("KtlintCheck", Exec::class) {
+        commandLine = commandLineArguments
+    }
+}
+
+/*
+ * Create a task in the root project that downloads ktlint.
+ */
+
+lateinit var ktlintDownloadTask: Task
+
+rootProject.afterEvaluate {
+    apply(plugin = "de.undercouch.download")
+    ktlintDownloadTask = createKtlintDownloadTask(this)
+
+    val enableKtlintChecks =
+        propertyBoolean(this, "org.thepalaceproject.build.enableKtLint")
+
+    if (enableKtlintChecks) {
+        val checkActual = createKtlintCheckTask(this)
+        checkActual.dependsOn.add(ktlintDownloadTask)
+        cleanTask.dependsOn.add(checkActual)
+    }
+}
+
 allprojects {
 
     /*
      * Configure the project metadata.
      */
 
-    this.group = property(this, "GROUP")
-    this.version = property(this, "VERSION_NAME")
+    this.group =
+        property(this, "GROUP")
+    this.version =
+        property(this, "VERSION_NAME")
 
     /*
      * Configure builds and tests for various project types.
@@ -354,11 +434,12 @@ allprojects {
             android.namespace =
                 property(this, "POM_ARTIFACT_ID")
             android.compileSdk =
-                propertyInt(this, "org.thepalaceproject.androidSDKCompile")
+                propertyInt(this, "org.thepalaceproject.build.androidSDKCompile")
 
             android.defaultConfig {
                 multiDexEnabled = true
-                minSdk = propertyInt(this@allprojects, "org.thepalaceproject.androidSDKMinimum")
+                minSdk =
+                    propertyInt(this@allprojects, "org.thepalaceproject.build.androidSDKMinimum")
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
 
@@ -391,7 +472,7 @@ allprojects {
 
             afterEvaluate {
                 val enableSemanticVersionChecks =
-                    propertyBoolean(this, "org.thepalaceproject.checkSemanticVersioning")
+                    propertyBoolean(this, "org.thepalaceproject.build.checkSemanticVersioning")
 
                 if (enableSemanticVersionChecks) {
                     val verifyActual = createScandoAnalyzeTask(this)
@@ -440,10 +521,6 @@ allprojects {
             afterEvaluate {
                 configurePublishingFor(this.project)
             }
-        }
-
-        "pom" -> {
-
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,8 @@ VERSION_PREVIOUS=1.0.1
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
 
-org.thepalaceproject.androidSDKCompile=33
-org.thepalaceproject.androidSDKMinimum=21
-org.thepalaceproject.checkSemanticVersioning=true
-org.thepalaceproject.publishSources=false
+org.thepalaceproject.build.androidSDKCompile=33
+org.thepalaceproject.build.androidSDKMinimum=21
+org.thepalaceproject.build.checkSemanticVersioning=true
+org.thepalaceproject.build.enableKtLint=true
+org.thepalaceproject.build.publishSources=false

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPAuthorizationBasic.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPAuthorizationBasic.kt
@@ -10,7 +10,7 @@ import java.nio.charset.Charset
 object LSHTTPAuthorizationBasic {
 
   private class Basic(
-    private val text: String
+    private val text: String,
   ) : LSHTTPAuthorizationType {
     override fun toHeaderValue(): String = this.text
   }
@@ -18,7 +18,7 @@ object LSHTTPAuthorizationBasic {
   fun ofUsernamePassword(
     userName: String,
     password: String,
-    encoding: Charset = Charsets.UTF_8
+    encoding: Charset = Charsets.UTF_8,
   ): LSHTTPAuthorizationType {
     val encoded =
       Base64Variants.MIME_NO_LINEFEEDS.encode("$userName:$password".toByteArray(encoding))

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPAuthorizationBearerToken.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPAuthorizationBearerToken.kt
@@ -7,13 +7,13 @@ package org.librarysimplified.http.api
 object LSHTTPAuthorizationBearerToken {
 
   private class Token(
-    private val text: String
+    private val text: String,
   ) : LSHTTPAuthorizationType {
     override fun toHeaderValue(): String = this.text
   }
 
   fun ofToken(
-    token: String
+    token: String,
   ): LSHTTPAuthorizationType {
     return Token("Bearer $token")
   }

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPClientConfiguration.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPClientConfiguration.kt
@@ -30,5 +30,5 @@ data class LSHTTPClientConfiguration(
    * The timeout used for all I/O operations (connects, reads, writes, etc).
    */
 
-  val timeout: Pair<Long, TimeUnit> = Pair(1L, TimeUnit.MINUTES)
+  val timeout: Pair<Long, TimeUnit> = Pair(1L, TimeUnit.MINUTES),
 )

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPClientProviderType.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPClientProviderType.kt
@@ -14,6 +14,6 @@ interface LSHTTPClientProviderType {
 
   fun create(
     context: Context,
-    configuration: LSHTTPClientConfiguration
+    configuration: LSHTTPClientConfiguration,
   ): LSHTTPClientType
 }

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPCookie.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPCookie.kt
@@ -15,5 +15,5 @@ data class LSHTTPCookie(
   val attributes: Map<String, String>,
   val secure: Boolean,
   val httpOnly: Boolean,
-  val expiresAt: LocalDateTime?
+  val expiresAt: LocalDateTime?,
 )

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPProblemReport.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPProblemReport.kt
@@ -10,7 +10,7 @@ data class LSHTTPProblemReport(
   val status: Int?,
   val title: String?,
   val detail: String?,
-  val type: String?
+  val type: String?,
 ) {
 
   /**

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPProblemReportParserFactoryType.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPProblemReportParserFactoryType.kt
@@ -15,6 +15,6 @@ interface LSHTTPProblemReportParserFactoryType {
 
   fun createParser(
     uri: String,
-    stream: InputStream
+    stream: InputStream,
   ): LSHTTPProblemReportParserType
 }

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestBuilderType.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestBuilderType.kt
@@ -30,7 +30,7 @@ interface LSHTTPRequestBuilderType {
      * Redirects between HTTP and HTTPS are allowed. This is unsafe!
      */
 
-    ALLOW_UNSAFE_REDIRECTS
+    ALLOW_UNSAFE_REDIRECTS,
   }
 
   /**
@@ -39,7 +39,7 @@ interface LSHTTPRequestBuilderType {
 
   fun addHeader(
     name: String,
-    value: String
+    value: String,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -47,7 +47,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun removeHeader(
-    name: String
+    name: String,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -55,7 +55,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun allowRedirects(
-    redirects: AllowRedirects
+    redirects: AllowRedirects,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -69,12 +69,12 @@ interface LSHTTPRequestBuilderType {
 
     data class Post(
       val body: ByteArray,
-      val contentType: MIMEType
+      val contentType: MIMEType,
     ) : Method()
 
     data class Put(
       val body: ByteArray,
-      val contentType: MIMEType
+      val contentType: MIMEType,
     ) : Method()
   }
 
@@ -83,7 +83,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun setMethod(
-    method: Method
+    method: Method,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -94,7 +94,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun setAuthorization(
-    authorization: LSHTTPAuthorizationType?
+    authorization: LSHTTPAuthorizationType?,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -103,7 +103,7 @@ interface LSHTTPRequestBuilderType {
 
   fun addCookie(
     name: String,
-    value: String
+    value: String,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -111,7 +111,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun removeCookie(
-    name: String
+    name: String,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -133,9 +133,8 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun setRequestModifier(
-    modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties
+    modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties,
   ): LSHTTPRequestBuilderType
-
 
   /**
    * Set an extension property of indefinite type.
@@ -143,7 +142,7 @@ interface LSHTTPRequestBuilderType {
 
   fun setExtensionProperty(
     key: String,
-    value: Any
+    value: Any,
   ): LSHTTPRequestBuilderType
 
   /**
@@ -157,7 +156,7 @@ interface LSHTTPRequestBuilderType {
    */
 
   fun setResponseObserver(
-    observer: (LSHTTPResponseType) -> Unit
+    observer: (LSHTTPResponseType) -> Unit,
   ): LSHTTPRequestBuilderType
 
   /**

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestProperties.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestProperties.kt
@@ -14,5 +14,5 @@ data class LSHTTPRequestProperties(
   val headers: SortedMap<String, String>,
   val method: Method,
   val authorization: LSHTTPAuthorizationType?,
-  val otherProperties: Map<String, Any>
+  val otherProperties: Map<String, Any>,
 )

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseProperties.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseProperties.kt
@@ -61,7 +61,7 @@ data class LSHTTPResponseProperties(
    * that was transparently negotiated by the client.
    */
 
-  val authorization: LSHTTPAuthorizationType? = null
+  val authorization: LSHTTPAuthorizationType? = null,
 ) {
 
   /**
@@ -77,5 +77,4 @@ data class LSHTTPResponseProperties(
 
   fun header(name: String): String? =
     this.headerValues(name).firstOrNull()
-
 }

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseStatus.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPResponseStatus.kt
@@ -38,7 +38,7 @@ sealed class LSHTTPResponseStatus {
 
     data class OK(
       override val properties: LSHTTPResponseProperties,
-      override val bodyStream: InputStream?
+      override val bodyStream: InputStream?,
     ) : Responded()
 
     /**
@@ -47,7 +47,7 @@ sealed class LSHTTPResponseStatus {
 
     data class Error(
       override val properties: LSHTTPResponseProperties,
-      override val bodyStream: InputStream?
+      override val bodyStream: InputStream?,
     ) : Responded()
   }
 
@@ -56,7 +56,7 @@ sealed class LSHTTPResponseStatus {
    */
 
   data class Failed(
-    val exception: Exception
+    val exception: Exception,
   ) : LSHTTPResponseStatus() {
     override val properties: LSHTTPResponseProperties? =
       null

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPTLSOverrides.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPTLSOverrides.kt
@@ -28,5 +28,5 @@ data class LSHTTPTLSOverrides(
    * The verifier used to check hostnames.
    */
 
-  val hostnameVerifier: HostnameVerifier
+  val hostnameVerifier: HostnameVerifier,
 )

--- a/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/LSSimplifiedBearerToken.kt
+++ b/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/LSSimplifiedBearerToken.kt
@@ -19,7 +19,7 @@ data class LSSimplifiedBearerToken(
   val expiresIn: BigInteger,
 
   @JsonProperty(value = "location", required = true)
-  val location: URI
+  val location: URI,
 ) {
 
   /**

--- a/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSHTTPBearerTokenInterceptor.kt
+++ b/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSHTTPBearerTokenInterceptor.kt
@@ -15,7 +15,7 @@ class LSHTTPBearerTokenInterceptor : Interceptor {
     LoggerFactory.getLogger(LSHTTPBearerTokenInterceptor::class.java)
 
   override fun intercept(
-    chain: Interceptor.Chain
+    chain: Interceptor.Chain,
   ): Response {
     val originalRequest = chain.request()
     val response = chain.proceed(originalRequest)
@@ -58,7 +58,6 @@ class LSHTTPBearerTokenInterceptor : Interceptor {
 
           proceedWithNewRequest(chain, newRequest0, target)
         } else if (!innerResponse.isSuccessful && wasRedirected) {
-
           /*
            * Some books may be hosted on a server (e.g. AWS) that errors when an authorization header
            * is sent. In this case, okhttp may return a bad request response (code 400) because it
@@ -97,9 +96,8 @@ class LSHTTPBearerTokenInterceptor : Interceptor {
   private fun proceedWithNewRequest(
     chain: Interceptor.Chain,
     oldRequest: Request,
-    target: String
+    target: String,
   ): Response {
-
     val request0Properties = oldRequest.tag(LSHTTPRequestProperties::class.java)!!
     val request1Properties = request0Properties.copy(authorization = null)
 
@@ -115,7 +113,7 @@ class LSHTTPBearerTokenInterceptor : Interceptor {
 
   private fun errorBadBearerToken(
     response: Response,
-    exception: Exception
+    exception: Exception,
   ): Response {
     this.logger.error("could not parse bearer token: ", exception)
     return response.newBuilder()

--- a/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSSimplifiedBearerTokenDeserializers.kt
+++ b/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSSimplifiedBearerTokenDeserializers.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
  */
 
 class LSSimplifiedBearerTokenDeserializers private constructor(
-  private val allowedClasses: Set<String>
+  private val allowedClasses: Set<String>,
 ) : SimpleDeserializers() {
 
   private val logger =
@@ -35,7 +35,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findArrayDeserializer(
@@ -43,7 +43,8 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   private fun checkAllowedClass(name: String) {
@@ -57,7 +58,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
   override fun findBeanDeserializer(
     type: JavaType,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.rawClass.canonicalName)
     return super.findBeanDeserializer(type, config, beanDesc)
@@ -69,7 +70,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findCollectionDeserializer(
@@ -77,7 +78,8 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -86,7 +88,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findCollectionLikeDeserializer(
@@ -94,14 +96,15 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
   override fun findEnumDeserializer(
     type: Class<*>,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.canonicalName)
     return super.findEnumDeserializer(type, config, beanDesc)
@@ -111,7 +114,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
   override fun findTreeNodeDeserializer(
     nodeType: Class<out JsonNode?>,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(nodeType.canonicalName)
     return super.findTreeNodeDeserializer(nodeType, config, beanDesc)
@@ -123,7 +126,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     contentTypeDeserializer: TypeDeserializer,
-    contentDeserializer: JsonDeserializer<*>?
+    contentDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(refType.toCanonical())
     return super.findReferenceDeserializer(
@@ -131,7 +134,8 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       config,
       beanDesc,
       contentTypeDeserializer,
-      contentDeserializer)
+      contentDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -141,7 +145,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     beanDesc: BeanDescription,
     keyDeserializer: KeyDeserializer,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findMapDeserializer(
@@ -150,7 +154,8 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       beanDesc,
       keyDeserializer,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -160,7 +165,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
     beanDesc: BeanDescription,
     keyDeserializer: KeyDeserializer,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findMapLikeDeserializer(
@@ -169,7 +174,8 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
       beanDesc,
       keyDeserializer,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   companion object {
@@ -182,7 +188,7 @@ class LSSimplifiedBearerTokenDeserializers private constructor(
         "java.lang.String",
         "java.math.BigInteger",
         "java.net.URI",
-        "org.librarysimplified.http.bearer_token.LSSimplifiedBearerToken"
+        "org.librarysimplified.http.bearer_token.LSSimplifiedBearerToken",
       )
     }
 

--- a/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSSimplifiedBearerTokenJSON.kt
+++ b/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSSimplifiedBearerTokenJSON.kt
@@ -14,7 +14,7 @@ object LSSimplifiedBearerTokenJSON {
 
   fun serializeToJSON(
     objectMapper: ObjectMapper,
-    token: LSSimplifiedBearerToken
+    token: LSSimplifiedBearerToken,
   ): ObjectNode {
     val node = objectMapper.createObjectNode()
     node.put("access_token", token.accessToken)
@@ -25,7 +25,7 @@ object LSSimplifiedBearerTokenJSON {
 
   fun serializeToText(
     objectMapper: ObjectMapper,
-    token: LSSimplifiedBearerToken
+    token: LSSimplifiedBearerToken,
   ): String {
     return ByteArrayOutputStream().use { stream ->
       val writer = objectMapper.writerWithDefaultPrettyPrinter()
@@ -35,17 +35,17 @@ object LSSimplifiedBearerTokenJSON {
   }
 
   fun serializeToText(
-    token: LSSimplifiedBearerToken
+    token: LSSimplifiedBearerToken,
   ): String {
     return serializeToText(
       objectMapper = LSSimplifiedBearerTokenObjectMappers.createObjectMapper(),
-      token = token
+      token = token,
     )
   }
 
   fun deserializeFromStream(
     objectMapper: ObjectMapper,
-    stream: InputStream
+    stream: InputStream,
   ): LSSimplifiedBearerToken {
     val factory = objectMapper.factory
     return factory.createParser(stream).use {
@@ -54,30 +54,30 @@ object LSSimplifiedBearerTokenJSON {
   }
 
   fun deserializeFromStream(
-    stream: InputStream
+    stream: InputStream,
   ): LSSimplifiedBearerToken {
     return deserializeFromStream(
       objectMapper = LSSimplifiedBearerTokenObjectMappers.createObjectMapper(),
-      stream = stream
+      stream = stream,
     )
   }
 
   fun deserializeFromText(
     objectMapper: ObjectMapper,
-    text: String
+    text: String,
   ): LSSimplifiedBearerToken {
     return deserializeFromStream(
       objectMapper = objectMapper,
-      stream = text.byteInputStream()
+      stream = text.byteInputStream(),
     )
   }
 
   fun deserializeFromText(
-    text: String
+    text: String,
   ): LSSimplifiedBearerToken {
     return deserializeFromText(
       objectMapper = LSSimplifiedBearerTokenObjectMappers.createObjectMapper(),
-      text = text
+      text = text,
     )
   }
 }

--- a/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloadRequest.kt
+++ b/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloadRequest.kt
@@ -52,5 +52,5 @@ data class LSHTTPDownloadRequest(
 
   val clock: () -> Instant = {
     Instant.now()
-  }
+  },
 )

--- a/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloadState.kt
+++ b/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloadState.kt
@@ -24,7 +24,7 @@ sealed class LSHTTPDownloadState {
   data class DownloadReceiving(
     val expectedSize: Long?,
     val receivedSize: Long,
-    val bytesPerSecond: Long
+    val bytesPerSecond: Long,
   ) : LSHTTPDownloadState()
 
   /**
@@ -61,7 +61,7 @@ sealed class LSHTTPDownloadState {
        */
 
       data class DownloadFailedServer(
-        override val responseStatus: LSHTTPResponseStatus.Responded
+        override val responseStatus: LSHTTPResponseStatus.Responded,
       ) : DownloadFailed()
 
       /**
@@ -73,7 +73,7 @@ sealed class LSHTTPDownloadState {
 
       data class DownloadFailedUnacceptableMIME(
         override val responseStatus: LSHTTPResponseStatus,
-        val exception: Throwable
+        val exception: Throwable,
       ) : DownloadFailed()
 
       /**
@@ -82,7 +82,7 @@ sealed class LSHTTPDownloadState {
 
       data class DownloadFailedExceptionally(
         override val responseStatus: LSHTTPResponseStatus?,
-        val exception: Throwable
+        val exception: Throwable,
       ) : DownloadFailed()
     }
 
@@ -92,7 +92,7 @@ sealed class LSHTTPDownloadState {
 
     data class DownloadCompletedSuccessfully(
       override val responseStatus: LSHTTPResponseStatus,
-      val receivedSize: Long
+      val receivedSize: Long,
     ) : LSHTTPDownloadResult()
   }
 }

--- a/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloads.kt
+++ b/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/LSHTTPDownloads.kt
@@ -14,7 +14,7 @@ object LSHTTPDownloads {
    */
 
   fun download(
-    request: LSHTTPDownloadRequest
+    request: LSHTTPDownloadRequest,
   ): LSHTTPDownloadResult {
     return this.create(request).execute()
   }
@@ -25,7 +25,7 @@ object LSHTTPDownloads {
    */
 
   fun create(
-    request: LSHTTPDownloadRequest
+    request: LSHTTPDownloadRequest,
   ): LSHTTPDownloadType {
     return LSHTTPDownload(request)
   }

--- a/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/internal/LSHTTPDownload.kt
+++ b/org.librarysimplified.http.downloads/src/main/java/org/librarysimplified/http/downloads/internal/LSHTTPDownload.kt
@@ -17,14 +17,14 @@ import java.io.InputStream
 import java.util.concurrent.CancellationException
 
 class LSHTTPDownload(
-  private val request: LSHTTPDownloadRequest
+  private val request: LSHTTPDownloadRequest,
 ) : LSHTTPDownloadType {
 
   private val logger =
     LoggerFactory.getLogger(LSHTTPDownload::class.java)
 
   private class UnacceptableMIME(
-    val status: LSHTTPResponseStatus.Responded.OK
+    val status: LSHTTPResponseStatus.Responded.OK,
   ) : Exception()
 
   override fun execute(): LSHTTPDownloadResult {
@@ -56,18 +56,18 @@ class LSHTTPDownload(
   }
 
   private fun handleFailed(
-    status: LSHTTPResponseStatus.Failed
+    status: LSHTTPResponseStatus.Failed,
   ): LSHTTPDownloadResult {
     val result = DownloadFailedExceptionally(
       responseStatus = status,
-      exception = status.exception
+      exception = status.exception,
     )
     this.request.onEvent(result)
     return result
   }
 
   private fun handleRespondedError(
-    status: LSHTTPResponseStatus.Responded.Error
+    status: LSHTTPResponseStatus.Responded.Error,
   ): LSHTTPDownloadResult {
     val result = DownloadFailedServer(status)
     this.request.onEvent(result)
@@ -75,7 +75,7 @@ class LSHTTPDownload(
   }
 
   private fun handleTransfer(
-    status: LSHTTPResponseStatus.Responded.OK
+    status: LSHTTPResponseStatus.Responded.OK,
   ): LSHTTPDownloadResult {
     this.checkMIME(status)
     this.checkCancellation()
@@ -86,7 +86,7 @@ class LSHTTPDownload(
     return this.transfer(
       status = status,
       expectedSize = status.properties.contentLength,
-      inputStream = inputStream
+      inputStream = inputStream,
     )
   }
 
@@ -99,7 +99,7 @@ class LSHTTPDownload(
   private fun transfer(
     status: LSHTTPResponseStatus,
     expectedSize: Long?,
-    inputStream: InputStream
+    inputStream: InputStream,
   ): LSHTTPDownloadResult {
     return this.request.outputFile.outputStream().use { outputStream ->
       val unitsPerSecond = LSHTTPDownloadUnitsPerSecond(this.request.clock)
@@ -110,8 +110,8 @@ class LSHTTPDownload(
         DownloadReceiving(
           expectedSize = expectedSize,
           receivedSize = total,
-          bytesPerSecond = 0L
-        )
+          bytesPerSecond = 0L,
+        ),
       )
 
       while (true) {
@@ -128,8 +128,8 @@ class LSHTTPDownload(
             DownloadReceiving(
               expectedSize = expectedSize,
               receivedSize = total,
-              bytesPerSecond = unitsPerSecond.now
-            )
+              bytesPerSecond = unitsPerSecond.now,
+            ),
           )
         }
       }
@@ -140,7 +140,7 @@ class LSHTTPDownload(
       val result =
         DownloadCompletedSuccessfully(
           receivedSize = total,
-          responseStatus = status
+          responseStatus = status,
         )
 
       this.request.onEvent(result)
@@ -150,7 +150,7 @@ class LSHTTPDownload(
 
   private fun checkOutputFile(
     expectedSize: Long?,
-    total: Long
+    total: Long,
   ) {
     val fileLength = this.request.outputFile.length()
     if (expectedSize != null && expectedSize >= 0) {

--- a/org.librarysimplified.http.oauth_client_credentials/build.gradle.kts
+++ b/org.librarysimplified.http.oauth_client_credentials/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.extraProperties
-
 dependencies {
     api(project(":org.librarysimplified.http.api"))
     api(project(":org.librarysimplified.http.vanilla"))

--- a/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/LSHTTPOAuthClientCredentialsToken.kt
+++ b/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/LSHTTPOAuthClientCredentialsToken.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.joda.time.LocalDateTime
 import java.math.BigInteger
-import java.net.URI
 
 /**
  * The type of bearer tokens.

--- a/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/LSHTTPOAuthClientCredentialsURIProperty.kt
+++ b/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/LSHTTPOAuthClientCredentialsURIProperty.kt
@@ -7,10 +7,8 @@ import java.net.URI
 private const val AUTHENTICATE_URI_PROPERTY_NAME =
   "org.librarysimplified.http.oauth_client_credentials.authenticateURI"
 
-
 val LSHTTPRequestProperties.oauthAuthenticateURI: URI?
   get() = otherProperties[AUTHENTICATE_URI_PROPERTY_NAME] as? URI?
-
 
 fun LSHTTPRequestBuilderType.setOAuthAuthenticateURI(uri: URI) {
   setExtensionProperty(AUTHENTICATE_URI_PROPERTY_NAME, uri)

--- a/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthClientCredentialsDeserializers.kt
+++ b/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthClientCredentialsDeserializers.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
  */
 
 class LSHTTPOAuthClientCredentialsDeserializers private constructor(
-  private val allowedClasses: Set<String>
+  private val allowedClasses: Set<String>,
 ) : SimpleDeserializers() {
 
   private val logger =
@@ -35,7 +35,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findArrayDeserializer(
@@ -43,7 +43,8 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   private fun checkAllowedClass(name: String) {
@@ -57,7 +58,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
   override fun findBeanDeserializer(
     type: JavaType,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.rawClass.canonicalName)
     return super.findBeanDeserializer(type, config, beanDesc)
@@ -69,7 +70,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findCollectionDeserializer(
@@ -77,7 +78,8 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -86,7 +88,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findCollectionLikeDeserializer(
@@ -94,14 +96,15 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       config,
       beanDesc,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
   override fun findEnumDeserializer(
     type: Class<*>,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.canonicalName)
     return super.findEnumDeserializer(type, config, beanDesc)
@@ -111,7 +114,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
   override fun findTreeNodeDeserializer(
     nodeType: Class<out JsonNode?>,
     config: DeserializationConfig,
-    beanDesc: BeanDescription
+    beanDesc: BeanDescription,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(nodeType.canonicalName)
     return super.findTreeNodeDeserializer(nodeType, config, beanDesc)
@@ -123,7 +126,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     config: DeserializationConfig,
     beanDesc: BeanDescription,
     contentTypeDeserializer: TypeDeserializer,
-    contentDeserializer: JsonDeserializer<*>?
+    contentDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(refType.toCanonical())
     return super.findReferenceDeserializer(
@@ -131,7 +134,8 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       config,
       beanDesc,
       contentTypeDeserializer,
-      contentDeserializer)
+      contentDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -141,7 +145,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     beanDesc: BeanDescription,
     keyDeserializer: KeyDeserializer,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findMapDeserializer(
@@ -150,7 +154,8 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       beanDesc,
       keyDeserializer,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   @Throws(JsonMappingException::class)
@@ -160,7 +165,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
     beanDesc: BeanDescription,
     keyDeserializer: KeyDeserializer,
     elementTypeDeserializer: TypeDeserializer,
-    elementDeserializer: JsonDeserializer<*>?
+    elementDeserializer: JsonDeserializer<*>?,
   ): JsonDeserializer<*>? {
     this.checkAllowedClass(type.toCanonical())
     return super.findMapLikeDeserializer(
@@ -169,7 +174,8 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       beanDesc,
       keyDeserializer,
       elementTypeDeserializer,
-      elementDeserializer)
+      elementDeserializer,
+    )
   }
 
   companion object {
@@ -181,7 +187,7 @@ class LSHTTPOAuthClientCredentialsDeserializers private constructor(
       return setOf(
         "java.lang.String",
         "java.math.BigInteger",
-        "org.librarysimplified.http.oauth_client_credentials.LSHTTPOAuthClientCredentialsToken"
+        "org.librarysimplified.http.oauth_client_credentials.LSHTTPOAuthClientCredentialsToken",
       )
     }
 

--- a/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthClientCredentialsTokenJSON.kt
+++ b/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthClientCredentialsTokenJSON.kt
@@ -14,7 +14,7 @@ object LSHTTPOAuthClientCredentialsTokenJSON {
 
   fun serializeToJSON(
     objectMapper: ObjectMapper,
-    token: LSHTTPOAuthClientCredentialsToken
+    token: LSHTTPOAuthClientCredentialsToken,
   ): ObjectNode {
     val node = objectMapper.createObjectNode()
     node.put("access_token", token.accessToken)
@@ -24,7 +24,7 @@ object LSHTTPOAuthClientCredentialsTokenJSON {
 
   fun serializeToText(
     objectMapper: ObjectMapper,
-    token: LSHTTPOAuthClientCredentialsToken
+    token: LSHTTPOAuthClientCredentialsToken,
   ): String {
     return ByteArrayOutputStream().use { stream ->
       val writer = objectMapper.writerWithDefaultPrettyPrinter()
@@ -34,17 +34,17 @@ object LSHTTPOAuthClientCredentialsTokenJSON {
   }
 
   fun serializeToText(
-    token: LSHTTPOAuthClientCredentialsToken
+    token: LSHTTPOAuthClientCredentialsToken,
   ): String {
     return serializeToText(
       objectMapper = LSHTTPOAuthClientCredentialsObjectMappers.createObjectMapper(),
-      token = token
+      token = token,
     )
   }
 
   fun deserializeFromStream(
     objectMapper: ObjectMapper,
-    stream: InputStream
+    stream: InputStream,
   ): LSHTTPOAuthClientCredentialsToken {
     val factory = objectMapper.factory
     return factory.createParser(stream).use {
@@ -53,30 +53,30 @@ object LSHTTPOAuthClientCredentialsTokenJSON {
   }
 
   fun deserializeFromStream(
-    stream: InputStream
+    stream: InputStream,
   ): LSHTTPOAuthClientCredentialsToken {
     return deserializeFromStream(
       objectMapper = LSHTTPOAuthClientCredentialsObjectMappers.createObjectMapper(),
-      stream = stream
+      stream = stream,
     )
   }
 
   fun deserializeFromText(
     objectMapper: ObjectMapper,
-    text: String
+    text: String,
   ): LSHTTPOAuthClientCredentialsToken {
     return deserializeFromStream(
       objectMapper = objectMapper,
-      stream = text.byteInputStream()
+      stream = text.byteInputStream(),
     )
   }
 
   fun deserializeFromText(
-    text: String
+    text: String,
   ): LSHTTPOAuthClientCredentialsToken {
     return deserializeFromText(
       objectMapper = LSHTTPOAuthClientCredentialsObjectMappers.createObjectMapper(),
-      text = text
+      text = text,
     )
   }
 }

--- a/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthTokenRepository.kt
+++ b/org.librarysimplified.http.oauth_client_credentials/src/main/java/org/librarysimplified/http/oauth_client_credentials/internal/LSHTTPOAuthTokenRepository.kt
@@ -6,7 +6,7 @@ class LSHTTPOAuthTokenRepository<K, V> {
 
   data class Expirable<V>(
     val item: V,
-    val expiresAt: LocalDateTime
+    val expiresAt: LocalDateTime,
   )
 
   private val locks: MutableMap<K, Any> =
@@ -24,7 +24,7 @@ class LSHTTPOAuthTokenRepository<K, V> {
     // Get or refresh the item while holding the per-key lock.
     return synchronized(lock) {
       val item = items[key]
-        ?.takeUnless { it.expiresAt < LocalDateTime.now()  }
+        ?.takeUnless { it.expiresAt < LocalDateTime.now() }
         ?: refresh(key).also { items[key] = it }
       item.item
     }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
@@ -31,7 +31,6 @@ import org.librarysimplified.http.vanilla.internal.LSHTTPMimeTypes.octetStream
 import org.mockito.Mockito
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.io.IOException
 import java.io.InterruptedIOException
 import java.util.concurrent.TimeUnit
 
@@ -47,7 +46,7 @@ abstract class LSHTTPClientContract {
   private lateinit var context: Context
 
   abstract fun clients(
-    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers()
+    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers(),
   ): LSHTTPClientProviderType
 
   @BeforeEach
@@ -60,7 +59,7 @@ abstract class LSHTTPClientContract {
     this.configuration =
       LSHTTPClientConfiguration(
         applicationName = "HttpTests",
-        applicationVersion = "1.0.0"
+        applicationVersion = "1.0.0",
       )
 
     this.server.start(30000)
@@ -231,7 +230,7 @@ abstract class LSHTTPClientContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "&gibberish ne cede malis")
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -262,9 +261,9 @@ abstract class LSHTTPClientContract {
           LSHTTPTestDirectories.stringOf(
             LSHTTPTestDirectories::class.java,
             this.directory,
-            "error.json"
-          )
-        )
+            "error.json",
+          ),
+        ),
     )
 
     val clients = this.clients()
@@ -281,7 +280,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals("You do not have enough credit.", problemReport.title)
       Assertions.assertEquals(
         "Your current balance is 30, but that costs 50.",
-        problemReport.detail
+        problemReport.detail,
       )
     }
   }
@@ -300,9 +299,9 @@ abstract class LSHTTPClientContract {
           LSHTTPTestDirectories.stringOf(
             LSHTTPTestDirectories::class.java,
             this.directory,
-            "invalid0.json"
-          )
-        )
+            "invalid0.json",
+          ),
+        ),
     )
 
     val clients = this.clients()
@@ -358,13 +357,13 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello elsewhere.")
+        .setBody("Hello elsewhere."),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
-        .setHeader("Location", this.serverElsewhere.url("/abc"))
+        .setHeader("Location", this.serverElsewhere.url("/abc")),
     )
 
     val clients = this.clients()
@@ -379,7 +378,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello elsewhere.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -401,13 +400,13 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello elsewhere.")
+        .setBody("Hello elsewhere."),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
-        .setHeader("Location", this.serverElsewhere.url("/abc"))
+        .setHeader("Location", this.serverElsewhere.url("/abc")),
     )
 
     val clients = this.clients()
@@ -423,7 +422,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(301, status.properties.status)
       Assertions.assertEquals(
         this.serverElsewhere.url("/abc").toString(),
-        status.properties.header("Location")
+        status.properties.header("Location"),
       )
     }
 
@@ -441,7 +440,7 @@ abstract class LSHTTPClientContract {
   fun testClientRequestAuthorizationBasic() {
     this.server.enqueue(
       MockResponse()
-        .setResponseCode(200)
+        .setResponseCode(200),
     )
 
     val clients = this.clients()
@@ -469,7 +468,7 @@ abstract class LSHTTPClientContract {
   fun testClientRequestAuthorizationBearer() {
     this.server.enqueue(
       MockResponse()
-        .setResponseCode(200)
+        .setResponseCode(200),
     )
 
     val clients = this.clients()
@@ -498,13 +497,13 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello elsewhere.")
+        .setBody("Hello elsewhere."),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(302)
-        .setHeader("Location", this.serverElsewhere.url("/abc"))
+        .setHeader("Location", this.serverElsewhere.url("/abc")),
     )
 
     val clients = this.clients()
@@ -520,7 +519,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello elsewhere.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -544,7 +543,7 @@ abstract class LSHTTPClientContract {
         .setResponseCode(200)
         .addHeader("Set-Cookie", "x=y; Expires=Mon, 01 Jan 2020 00:00:00 UTC;")
         .addHeader("Set-Cookie", "a=b; Secure")
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -558,7 +557,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
 
       Assertions.assertEquals(2, status.properties.cookies.size)
@@ -592,14 +591,14 @@ abstract class LSHTTPClientContract {
         .setResponseCode(200)
         .addHeader("Set-Cookie", "x=y; Expires=Mon, 01 Jan 2020 00:00:00 UTC;")
         .addHeader("Set-Cookie", "a=b; Secure")
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.serverElsewhere.url("/abc"))
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -613,7 +612,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
 
       Assertions.assertEquals(2, status.properties.cookies.size)
@@ -645,7 +644,7 @@ abstract class LSHTTPClientContract {
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -664,7 +663,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -682,7 +681,7 @@ abstract class LSHTTPClientContract {
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -699,7 +698,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -717,14 +716,14 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.serverElsewhere.url("/abc"))
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()
@@ -741,7 +740,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -766,12 +765,12 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     this.server.useHttps(
       sslSocketFactory = tls.serverContext.socketFactory,
-      tunnelProxy = false
+      tunnelProxy = false,
     )
 
     this.configuration =
@@ -779,14 +778,15 @@ abstract class LSHTTPClientContract {
         tlsOverrides = LSHTTPTLSOverrides(
           tls.clientContext.socketFactory,
           LSHTTPUnsafeTLS.unsafeTrustManager(),
-          LSHTTPUnsafeTLS.unsafeHostnameVerifier()
-        ))
+          LSHTTPUnsafeTLS.unsafeHostnameVerifier(),
+        ),
+      )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.serverElsewhere.url("/abc"))
-        .setBody("Redirect!")
+        .setBody("Redirect!"),
     )
 
     val clients = this.clients()
@@ -801,7 +801,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals("Refused to follow a redirect to ${this.serverElsewhere.url("/abc")}.", status.properties.message)
       Assertions.assertEquals(
         "Redirect!",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -823,12 +823,12 @@ abstract class LSHTTPClientContract {
     this.serverElsewhere.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     this.server.useHttps(
       sslSocketFactory = tls.serverContext.socketFactory,
-      tunnelProxy = false
+      tunnelProxy = false,
     )
 
     this.configuration =
@@ -836,14 +836,15 @@ abstract class LSHTTPClientContract {
         tlsOverrides = LSHTTPTLSOverrides(
           tls.clientContext.socketFactory,
           LSHTTPUnsafeTLS.unsafeTrustManager(),
-          LSHTTPUnsafeTLS.unsafeHostnameVerifier()
-        ))
+          LSHTTPUnsafeTLS.unsafeHostnameVerifier(),
+        ),
+      )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.serverElsewhere.url("/abc"))
-        .setBody("Redirect!")
+        .setBody("Redirect!"),
     )
 
     val clients = this.clients()
@@ -858,7 +859,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "Hello.",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -879,20 +880,20 @@ abstract class LSHTTPClientContract {
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.server.url("/a"))
-        .setBody("Redirect to /a")
+        .setBody("Redirect to /a"),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.server.url("/b"))
-        .setBody("Redirect to /b")
+        .setBody("Redirect to /b"),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("End!")
+        .setBody("End!"),
     )
 
     val clients = this.clients()
@@ -918,7 +919,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "End!",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -947,20 +948,20 @@ abstract class LSHTTPClientContract {
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.server.url("/a"))
-        .setBody("Redirect to /a")
+        .setBody("Redirect to /a"),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(301)
         .setHeader("Location", this.server.url("/b"))
-        .setBody("Redirect to /b")
+        .setBody("Redirect to /b"),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
-        .setBody("End!")
+        .setBody("End!"),
     )
 
     val responses = mutableListOf<LSHTTPResponseType>()
@@ -976,7 +977,7 @@ abstract class LSHTTPClientContract {
       Assertions.assertEquals(200, status.properties.status)
       Assertions.assertEquals(
         "End!",
-        String(status.bodyStream?.readBytes() ?: ByteArray(0))
+        String(status.bodyStream?.readBytes() ?: ByteArray(0)),
       )
     }
 
@@ -1056,7 +1057,7 @@ abstract class LSHTTPClientContract {
     this.server.enqueue(
       MockResponse()
         .setBodyDelay(10L, TimeUnit.SECONDS)
-        .setBody("Hello.")
+        .setBody("Hello."),
     )
 
     val clients = this.clients()

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientTest.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientTest.kt
@@ -8,7 +8,7 @@ class LSHTTPClientTest : LSHTTPClientContract() {
   override fun clients(parsers: LSHTTPProblemReportParserFactoryType): LSHTTPClientProviderType {
     return LSHTTPClients(
       parsers,
-      listOf()
+      listOf(),
     )
   }
 }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPProblemReportParserContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPProblemReportParserContract.kt
@@ -27,7 +27,7 @@ abstract class LSHTTPProblemReportParserContract {
     val status =
       parsers.createParser(
         "urn:test",
-        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "valid0.json")
+        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "valid0.json"),
       ).use(LSHTTPProblemReportParserType::execute)
 
     Assertions.assertEquals("https://example.com/probs/out-of-credit", status.type)
@@ -42,7 +42,7 @@ abstract class LSHTTPProblemReportParserContract {
     val status =
       parsers.createParser(
         "urn:test",
-        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "valid1.json")
+        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "valid1.json"),
       ).use(LSHTTPProblemReportParserType::execute)
 
     Assertions.assertEquals(null, status.type)
@@ -58,7 +58,7 @@ abstract class LSHTTPProblemReportParserContract {
     Assertions.assertThrows(IOException::class.java) {
       parsers.createParser(
         "urn:test",
-        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "invalid0.json")
+        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "invalid0.json"),
       ).use(LSHTTPProblemReportParserType::execute)
     }
   }
@@ -70,7 +70,7 @@ abstract class LSHTTPProblemReportParserContract {
     Assertions.assertThrows(IOException::class.java) {
       parsers.createParser(
         "urn:test",
-        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "invalid1.json")
+        resourceStreamOf(LSHTTPTestDirectories::class.java, this.testDirectory, "invalid1.json"),
       ).use(LSHTTPProblemReportParserType::execute)
     }
   }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPTestDirectories.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPTestDirectories.kt
@@ -32,7 +32,7 @@ object LSHTTPTestDirectories {
   fun resourceOf(
     clazz: Class<*> = LSHTTPTestDirectories::class.java,
     output: File,
-    name: String
+    name: String,
   ): File {
     val internal = String.format("/org/librarysimplified/http/tests/%s", name)
     val url = clazz.getResource(internal) ?: throw NoSuchFileException(File(internal))
@@ -46,7 +46,7 @@ object LSHTTPTestDirectories {
   fun resourceStreamOf(
     clazz: Class<*> = LSHTTPTestDirectories::class.java,
     output: File,
-    name: String
+    name: String,
   ): InputStream {
     return resourceOf(clazz, output, name).inputStream()
   }
@@ -54,7 +54,7 @@ object LSHTTPTestDirectories {
   fun stringOf(
     clazz: Class<*> = LSHTTPTestDirectories::class.java,
     output: File,
-    name: String
+    name: String,
   ): String {
     return String(resourceOf(clazz, output, name).inputStream().readBytes())
   }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPTestTLS.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPTestTLS.kt
@@ -21,14 +21,13 @@ import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
 
-
 class LSHTTPTestTLS(
   val clientKeyPair: KeyPair,
   val clientCert: X509Certificate,
   val clientContext: SSLContext,
   val serverKeyPair: KeyPair,
   val serverCert: X509Certificate,
-  val serverContext: SSLContext
+  val serverContext: SSLContext,
 ) {
 
   companion object {
@@ -47,7 +46,7 @@ class LSHTTPTestTLS(
       LoggerFactory.getLogger(LSHTTPTestTLS::class.java)
 
     fun createRSAKeyPair(
-      name: String
+      name: String,
     ): KeyPair {
       this.logger.debug("generating $name keypair")
       val generator = KeyPairGenerator.getInstance("RSA")
@@ -69,14 +68,14 @@ class LSHTTPTestTLS(
           name = "client",
           ownKeyPair = clientKeyPair,
           ownCert = clientCert,
-          peerCert = serverCert
+          peerCert = serverCert,
         )
       val serverContext =
         this.createSSLContext(
           name = "server",
           ownKeyPair = serverKeyPair,
           ownCert = serverCert,
-          peerCert = clientCert
+          peerCert = clientCert,
         )
 
       return LSHTTPTestTLS(
@@ -85,7 +84,7 @@ class LSHTTPTestTLS(
         clientContext,
         serverKeyPair,
         serverCert,
-        serverContext
+        serverContext,
       )
     }
 
@@ -93,7 +92,7 @@ class LSHTTPTestTLS(
       name: String,
       ownKeyPair: KeyPair,
       ownCert: X509Certificate,
-      peerCert: X509Certificate
+      peerCert: X509Certificate,
     ): SSLContext {
       this.logger.debug("creating $name SSL context")
 
@@ -135,7 +134,7 @@ class LSHTTPTestTLS(
     fun createCertificate(
       name: String,
       keyPair: KeyPair,
-      subjectDN: String
+      subjectDN: String,
     ): X509Certificate {
       this.logger.debug("creating $name X509 certificate")
 
@@ -159,7 +158,7 @@ class LSHTTPTestTLS(
           startDate,
           endDate,
           dnName,
-          keyPair.public
+          keyPair.public,
         )
 
       return JcaX509CertificateConverter()

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPUnsafeTLS.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPUnsafeTLS.kt
@@ -14,14 +14,14 @@ object LSHTTPUnsafeTLS {
     return object : X509TrustManager {
       override fun checkClientTrusted(
         chain: Array<X509Certificate?>?,
-        authType: String?
+        authType: String?,
       ) {
         logger.debug("checkClientTrusted")
       }
 
       override fun checkServerTrusted(
         chain: Array<X509Certificate?>?,
-        authType: String?
+        authType: String?,
       ) {
         logger.debug("checkServerTrusted")
       }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
@@ -1,11 +1,17 @@
 package org.librarysimplified.http.tests.bearer_token
 
 import android.content.Context
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.librarysimplified.http.api.LSHTTPAuthorizationBearerToken
 import org.librarysimplified.http.api.LSHTTPClientConfiguration
@@ -18,12 +24,6 @@ import org.librarysimplified.http.bearer_token.LSHTTPBearerTokenInterceptors
 import org.librarysimplified.http.tests.LSHTTPTestDirectories
 import org.librarysimplified.http.vanilla.LSHTTPProblemReportParsers
 import org.mockito.Mockito
-import com.nhaarman.mockitokotlin2.anyOrNull
-import com.nhaarman.mockitokotlin2.argThat
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.inOrder
-import com.nhaarman.mockitokotlin2.mock
-import org.junit.jupiter.api.Disabled
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -36,7 +36,7 @@ abstract class LSHTTPBearerTokenContract {
   private lateinit var context: Context
 
   abstract fun clients(
-    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers()
+    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers(),
   ): LSHTTPClientProviderType
 
   @BeforeEach
@@ -49,7 +49,7 @@ abstract class LSHTTPBearerTokenContract {
     this.configuration =
       LSHTTPClientConfiguration(
         applicationName = "HttpTests",
-        applicationVersion = "1.0.0"
+        applicationVersion = "1.0.0",
       )
   }
 
@@ -95,15 +95,15 @@ abstract class LSHTTPBearerTokenContract {
   "expires_in": 1000,
   "location": "${this.server.url("/abc")}"
 }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("OK!")
+        .setBody("OK!"),
     )
 
     val clients = this.clients()
@@ -143,15 +143,15 @@ abstract class LSHTTPBearerTokenContract {
   "expires_in": 1000,
   "location": "${this.server.url("/abc")}"
 }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("OK!")
+        .setBody("OK!"),
     )
 
     val clients = this.clients()
@@ -180,13 +180,17 @@ abstract class LSHTTPBearerTokenContract {
     Assertions.assertEquals("Bearer abcd", sent1.getHeader("Authorization"))
 
     inOrder(requestModifier) {
-      verify(requestModifier).invoke(argThat {
-        authorization!!.toHeaderValue() == "Bearer original_token"
-      })
+      verify(requestModifier).invoke(
+        argThat {
+          authorization!!.toHeaderValue() == "Bearer original_token"
+        },
+      )
 
-      verify(requestModifier).invoke(argThat {
-        authorization!!.toHeaderValue() == "Bearer abcd"
-      })
+      verify(requestModifier).invoke(
+        argThat {
+          authorization!!.toHeaderValue() == "Bearer abcd"
+        },
+      )
     }
   }
 
@@ -208,15 +212,15 @@ abstract class LSHTTPBearerTokenContract {
   with only Leela to talk to. I think he still holds the grudge. You don't think I'm sarcastic, 
   do you?
 }
-          """.trimIndent()
-        )
+          """.trimIndent(),
+        ),
     )
 
     this.server.enqueue(
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("OK!")
+        .setBody("OK!"),
     )
 
     val clients = this.clients()

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenTest.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenTest.kt
@@ -9,7 +9,7 @@ class LSHTTPBearerTokenTest : LSHTTPBearerTokenContract() {
   override fun clients(parsers: LSHTTPProblemReportParserFactoryType): LSHTTPClientProviderType {
     return LSHTTPClients(
       parsers,
-      listOf(LSHTTPBearerTokenInterceptors())
+      listOf(LSHTTPBearerTokenInterceptors()),
     )
   }
 }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSSimplifiedBearerTokenJSONTest.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSSimplifiedBearerTokenJSONTest.kt
@@ -22,9 +22,12 @@ class LSSimplifiedBearerTokenJSONTest {
   @Test
   fun testRequiredField1() {
     val ex = Assertions.assertThrows(Exception::class.java) {
-      LSSimplifiedBearerTokenJSON.deserializeFromText("""{
+      LSSimplifiedBearerTokenJSON.deserializeFromText(
+        """{
         "access_token": "abcd"
-      }""".trimIndent())
+      }
+        """.trimIndent(),
+      )
     }
 
     assertTrue(ex.message!!.contains("expires_in"))
@@ -33,10 +36,13 @@ class LSSimplifiedBearerTokenJSONTest {
   @Test
   fun testRequiredField2() {
     val ex = Assertions.assertThrows(Exception::class.java) {
-      LSSimplifiedBearerTokenJSON.deserializeFromText("""{
+      LSSimplifiedBearerTokenJSON.deserializeFromText(
+        """{
         "access_token": "abcd",
         "expires_in": 1000
-      }""".trimIndent())
+      }
+        """.trimIndent(),
+      )
     }
 
     assertTrue(ex.message!!.contains("location"))
@@ -45,11 +51,14 @@ class LSSimplifiedBearerTokenJSONTest {
   @Test
   fun badURI0() {
     val ex = Assertions.assertThrows(Exception::class.java) {
-      LSSimplifiedBearerTokenJSON.deserializeFromText("""{
+      LSSimplifiedBearerTokenJSON.deserializeFromText(
+        """{
         "access_token": "abcd",
         "expires_in": 1000,
         "location": " not a uri "
-      }""".trimIndent())
+      }
+        """.trimIndent(),
+      )
     }
 
     assertTrue(ex.message!!.contains("location"))
@@ -58,11 +67,14 @@ class LSSimplifiedBearerTokenJSONTest {
   @Test
   fun ok0() {
     val token =
-      LSSimplifiedBearerTokenJSON.deserializeFromText("""{
+      LSSimplifiedBearerTokenJSON.deserializeFromText(
+        """{
         "access_token": "abcd",
         "expires_in": 1000,
         "location": "https://www.example.com"
-      }""".trimIndent())
+      }
+        """.trimIndent(),
+      )
 
     assertEquals("abcd", token.accessToken)
     assertEquals(BigInteger.valueOf(1000L), token.expiresIn)
@@ -72,11 +84,14 @@ class LSSimplifiedBearerTokenJSONTest {
   @Test
   fun roundTrip0() {
     val token0 =
-      LSSimplifiedBearerTokenJSON.deserializeFromText("""{
+      LSSimplifiedBearerTokenJSON.deserializeFromText(
+        """{
         "access_token": "abcd",
         "expires_in": 1000,
         "location": "https://www.example.com"
-      }""".trimIndent())
+      }
+        """.trimIndent(),
+      )
 
     val token1 =
       LSSimplifiedBearerTokenJSON.deserializeFromText(LSSimplifiedBearerTokenJSON.serializeToText(token0))

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/downloads/LSHTTPDownloadsContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/downloads/LSHTTPDownloadsContract.kt
@@ -45,7 +45,7 @@ abstract class LSHTTPDownloadsContract {
   private lateinit var context: Context
 
   abstract fun clients(
-    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers()
+    parsers: LSHTTPProblemReportParserFactoryType = LSHTTPProblemReportParsers(),
   ): LSHTTPClientProviderType
 
   @BeforeEach
@@ -59,7 +59,7 @@ abstract class LSHTTPDownloadsContract {
     this.configuration =
       LSHTTPClientConfiguration(
         applicationName = "HttpTests",
-        applicationVersion = "1.0.0"
+        applicationVersion = "1.0.0",
       )
   }
 
@@ -96,7 +96,7 @@ abstract class LSHTTPDownloadsContract {
         request = request,
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     val result = LSHTTPDownloads.download(downloadRequest) as DownloadFailed
@@ -128,7 +128,7 @@ abstract class LSHTTPDownloadsContract {
         request = request,
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     val result = LSHTTPDownloads.download(downloadRequest) as DownloadFailedExceptionally
@@ -150,7 +150,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     val clients = this.clients()
@@ -167,7 +167,7 @@ abstract class LSHTTPDownloadsContract {
         request = request,
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { true }
+        isCancelled = { true },
       )
 
     LSHTTPDownloads.download(downloadRequest) as DownloadCancelled
@@ -188,7 +188,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     val clients = this.clients()
@@ -205,7 +205,7 @@ abstract class LSHTTPDownloadsContract {
         request = request,
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     val result = LSHTTPDownloads.download(downloadRequest) as DownloadCompletedSuccessfully
@@ -230,7 +230,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     val clients = this.clients()
@@ -248,7 +248,7 @@ abstract class LSHTTPDownloadsContract {
         outputFile = outputFile,
         onEvent = this::logEvent,
         isMIMETypeAcceptable = { false },
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     LSHTTPDownloads.download(downloadRequest) as DownloadFailedUnacceptableMIME
@@ -274,7 +274,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setChunkedBody(buffer, 8)
+        .setChunkedBody(buffer, 8),
     )
 
     val clients = this.clients()
@@ -291,7 +291,7 @@ abstract class LSHTTPDownloadsContract {
         request = request,
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     val result = LSHTTPDownloads.download(downloadRequest) as DownloadCompletedSuccessfully
@@ -310,7 +310,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     val clients = this.clients()
@@ -330,7 +330,7 @@ abstract class LSHTTPDownloadsContract {
         isMIMETypeAcceptable = {
           throw IllegalArgumentException()
         },
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     LSHTTPDownloads.download(downloadRequest) as DownloadFailedExceptionally
@@ -351,7 +351,7 @@ abstract class LSHTTPDownloadsContract {
       MockResponse()
         .setResponseCode(200)
         .setHeader("content-type", "text/plain")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     this.server.enqueue(
@@ -359,7 +359,7 @@ abstract class LSHTTPDownloadsContract {
         .setResponseCode(302)
         .setHeader("Location", this.serverElsewhere.url("/abc"))
         .setHeader("content-type", "text/html")
-        .setBody("Hello!")
+        .setBody("Hello!"),
     )
 
     val clients = this.clients()
@@ -375,11 +375,12 @@ abstract class LSHTTPDownloadsContract {
       LSHTTPDownloadRequest(
         request = request,
         isMIMETypeAcceptable = {
-          type -> type.fullType == "text/plain"
+            type ->
+          type.fullType == "text/plain"
         },
         outputFile = outputFile,
         onEvent = this::logEvent,
-        isCancelled = { false }
+        isCancelled = { false },
       )
 
     val result = LSHTTPDownloads.download(downloadRequest) as DownloadCompletedSuccessfully

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/downloads/LSHTTPDownloadsTest.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/downloads/LSHTTPDownloadsTest.kt
@@ -8,7 +8,7 @@ class LSHTTPDownloadsTest : LSHTTPDownloadsContract() {
   override fun clients(parsers: LSHTTPProblemReportParserFactoryType): LSHTTPClientProviderType {
     return LSHTTPClients(
       parsers,
-      listOf()
+      listOf(),
     )
   }
 }

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/uri_builder/LSHTTPURIQueryBuilderTest.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/uri_builder/LSHTTPURIQueryBuilderTest.kt
@@ -12,7 +12,7 @@ class LSHTTPURIQueryBuilderTest {
     val uri =
       LSHTTPURIQueryBuilder.encodeQuery(
         base = URI.create("http://www.example.com"),
-        parameters = sortedMapOf()
+        parameters = sortedMapOf(),
       )
 
     Assertions.assertEquals("http://www.example.com", uri.toString())
@@ -27,7 +27,7 @@ class LSHTTPURIQueryBuilderTest {
           Pair("a", "x"),
           Pair("b", "y"),
           Pair("c", "z"),
-        )
+        ),
       )
 
     Assertions.assertEquals("http://www.example.com?a=x&b=y&c=z", uri.toString())

--- a/org.librarysimplified.http.uri_builder/src/main/java/org/librarysimplified/http/uri_builder/LSHTTPURIQueryBuilder.kt
+++ b/org.librarysimplified.http.uri_builder/src/main/java/org/librarysimplified/http/uri_builder/LSHTTPURIQueryBuilder.kt
@@ -22,7 +22,7 @@ object LSHTTPURIQueryBuilder {
 
   fun encodeQuery(
     base: URI,
-    parameters: SortedMap<String, String>
+    parameters: SortedMap<String, String>,
   ): URI {
     return try {
       if (parameters.isEmpty()) {

--- a/org.librarysimplified.http.vanilla/build.gradle.kts
+++ b/org.librarysimplified.http.vanilla/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.extraProperties
-
 dependencies {
     api(project(":org.librarysimplified.http.api"))
 

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/LSHTTPClients.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/LSHTTPClients.kt
@@ -7,7 +7,6 @@ import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.http.api.LSHTTPProblemReportParserFactoryType
 import org.librarysimplified.http.vanilla.extensions.LSHTTPInterceptorFactoryType
 import org.librarysimplified.http.vanilla.internal.LSHTTPClient
-import org.slf4j.LoggerFactory
 import java.util.ServiceLoader
 
 /**
@@ -16,23 +15,23 @@ import java.util.ServiceLoader
 
 class LSHTTPClients(
   private val problemReportParsers: LSHTTPProblemReportParserFactoryType,
-  private val interceptors: List<LSHTTPInterceptorFactoryType>
+  private val interceptors: List<LSHTTPInterceptorFactoryType>,
 ) : LSHTTPClientProviderType {
 
   constructor() : this(
     problemReportParsers = LSHTTPProblemReportParsers(),
-    interceptors = ServiceLoader.load(LSHTTPInterceptorFactoryType::class.java).toList()
+    interceptors = ServiceLoader.load(LSHTTPInterceptorFactoryType::class.java).toList(),
   )
 
   override fun create(
     context: Context,
-    configuration: LSHTTPClientConfiguration
+    configuration: LSHTTPClientConfiguration,
   ): LSHTTPClientType {
     return LSHTTPClient(
       context = context,
       problemReportParsers = problemReportParsers,
       interceptors = interceptors,
-      configuration = configuration
+      configuration = configuration,
     )
   }
 }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/LSHTTPProblemReportParsers.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/LSHTTPProblemReportParsers.kt
@@ -12,7 +12,7 @@ import java.io.InputStream
 class LSHTTPProblemReportParsers : LSHTTPProblemReportParserFactoryType {
   override fun createParser(
     uri: String,
-    stream: InputStream
+    stream: InputStream,
   ): LSHTTPProblemReportParserType {
     return LSHTTPProblemReportParser(uri, stream)
   }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/extensions/LSHTTPInterceptorFactoryType.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/extensions/LSHTTPInterceptorFactoryType.kt
@@ -26,6 +26,6 @@ interface LSHTTPInterceptorFactoryType {
    */
 
   fun createInterceptor(
-    context: Context
+    context: Context,
   ): Interceptor
 }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPClient.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPClient.kt
@@ -12,13 +12,12 @@ import org.librarysimplified.http.vanilla.BuildConfig
 import org.librarysimplified.http.vanilla.extensions.LSHTTPInterceptorFactoryType
 import org.slf4j.LoggerFactory
 import java.net.URI
-import java.util.concurrent.TimeUnit
 
 class LSHTTPClient(
   val context: Context,
   val configuration: LSHTTPClientConfiguration,
   val problemReportParsers: LSHTTPProblemReportParserFactoryType,
-  val interceptors: List<LSHTTPInterceptorFactoryType>
+  val interceptors: List<LSHTTPInterceptorFactoryType>,
 ) : LSHTTPClientType {
 
   internal val logger =
@@ -37,9 +36,8 @@ class LSHTTPClient(
   internal fun createOkClient(
     redirects: LSHTTPRequestBuilderType.AllowRedirects,
     modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
-    observer: ((LSHTTPResponseType) -> Unit)?
+    observer: ((LSHTTPResponseType) -> Unit)?,
   ): OkHttpClient {
-
     val builder = OkHttpClient.Builder()
 
     if (modifier != null) {
@@ -84,7 +82,7 @@ class LSHTTPClient(
     if (tlsOverrides != null) {
       builder.sslSocketFactory(
         sslSocketFactory = tlsOverrides.sslSocketFactory,
-        trustManager = tlsOverrides.trustManager
+        trustManager = tlsOverrides.trustManager,
       )
       builder.hostnameVerifier(tlsOverrides.hostnameVerifier)
     }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPLoggingInterceptor.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPLoggingInterceptor.kt
@@ -9,7 +9,7 @@ import org.slf4j.Logger
  */
 
 class LSHTTPLoggingInterceptor(
-  private val logger: Logger
+  private val logger: Logger,
 ) : Interceptor {
 
   override fun intercept(chain: Interceptor.Chain): Response {
@@ -30,7 +30,7 @@ class LSHTTPLoggingInterceptor(
       response.code,
       response.message,
       response.body?.contentLength() ?: -1,
-      response.body?.contentType() ?: "?"
+      response.body?.contentType() ?: "?",
     )
     return response
   }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPProblemReportParser.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPProblemReportParser.kt
@@ -11,7 +11,7 @@ import java.io.InputStream
 
 class LSHTTPProblemReportParser(
   private val uri: String,
-  private val stream: InputStream
+  private val stream: InputStream,
 ) : LSHTTPProblemReportParserType {
 
   private val logger =
@@ -32,11 +32,11 @@ class LSHTTPProblemReportParser(
   }
 
   private class JsonException(
-    message: String
+    message: String,
   ) : JsonProcessingException(message)
 
   private fun fromObjectNode(
-    objectNode: ObjectNode
+    objectNode: ObjectNode,
   ): LSHTTPProblemReport {
     val statusNode = objectNode["status"]
     val typeNode = objectNode["type"]
@@ -75,7 +75,7 @@ class LSHTTPProblemReportParser(
       status = status,
       title = title,
       detail = detail,
-      type = type
+      type = type,
     )
   }
 

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
@@ -5,11 +5,11 @@ import okhttp3.Response
 import org.librarysimplified.http.api.LSHTTPRequestProperties
 
 class LSHTTPRedirectRequestInterceptor(
-  private val modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties
+  private val modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties,
 ) : Interceptor {
 
   override fun intercept(
-    chain: Interceptor.Chain
+    chain: Interceptor.Chain,
   ): Response {
     val request =
       chain.request()

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectResponseInterceptor.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectResponseInterceptor.kt
@@ -6,11 +6,11 @@ import org.librarysimplified.http.api.LSHTTPResponseType
 
 class LSHTTPRedirectResponseInterceptor(
   private val client: LSHTTPClient,
-  private val observer: (LSHTTPResponseType) -> Unit
+  private val observer: (LSHTTPResponseType) -> Unit,
 ) : Interceptor {
 
   override fun intercept(
-    chain: Interceptor.Chain
+    chain: Interceptor.Chain,
   ): Response {
     val response = chain.proceed(chain.request())
     this.observer.invoke(LSHTTPResponse.ofOkResponse(this.client, response))

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequest.kt
@@ -12,7 +12,7 @@ class LSHTTPRequest(
   private val allowRedirects: AllowRedirects,
   override val properties: LSHTTPRequestProperties,
   private val modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
-  private val observer: ((LSHTTPResponseType) -> Unit)?
+  private val observer: ((LSHTTPResponseType) -> Unit)?,
 ) : LSHTTPRequestType {
 
   private lateinit var request: Request
@@ -25,14 +25,14 @@ class LSHTTPRequest(
       this.client.logger.debug(
         "[{}] creating client with {}",
         this.request.url,
-        this.allowRedirects
+        this.allowRedirects,
       )
 
       val okClient =
         this.client.createOkClient(
           redirects = this.allowRedirects,
           modifier = this.modifier,
-          observer = this.observer
+          observer = this.observer,
         )
       val call = okClient.newCall(this.request)
       val response = call.execute()
@@ -41,11 +41,11 @@ class LSHTTPRequest(
       this.client.logger.error(
         "[{}]: request failed: ",
         this.request.url,
-        e
+        e,
       )
       return LSHTTPResponse(
         status = LSHTTPResponseStatus.Failed(e),
-        response = null
+        response = null,
       )
     }
   }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequestBuilder.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRequestBuilder.kt
@@ -14,7 +14,7 @@ import java.util.TreeMap
 
 class LSHTTPRequestBuilder(
   private val client: LSHTTPClient,
-  private val target: URI
+  private val target: URI,
 ) : LSHTTPRequestBuilderType {
 
   private var observer: ((LSHTTPResponseType) -> Unit)? = null
@@ -28,7 +28,7 @@ class LSHTTPRequestBuilder(
       headers = sortedMapOf(),
       method = Get,
       authorization = null,
-      otherProperties = emptyMap()
+      otherProperties = emptyMap(),
     )
 
   init {
@@ -41,7 +41,7 @@ class LSHTTPRequestBuilder(
 
   override fun addHeader(
     name: String,
-    value: String
+    value: String,
   ): LSHTTPRequestBuilderType {
     val oldHeaders = TreeMap(this.properties.headers)
     oldHeaders[name] = value
@@ -50,7 +50,7 @@ class LSHTTPRequestBuilder(
   }
 
   override fun removeHeader(
-    name: String
+    name: String,
   ): LSHTTPRequestBuilderType {
     val oldHeaders = TreeMap(this.properties.headers)
     oldHeaders.remove(name)
@@ -59,21 +59,21 @@ class LSHTTPRequestBuilder(
   }
 
   override fun allowRedirects(
-    redirects: AllowRedirects
+    redirects: AllowRedirects,
   ): LSHTTPRequestBuilderType {
     this.redirects = redirects
     return this
   }
 
   override fun setMethod(
-    method: Method
+    method: Method,
   ): LSHTTPRequestBuilderType {
     this.properties = this.properties.copy(method = method)
     return this
   }
 
   override fun setAuthorization(
-    authorization: LSHTTPAuthorizationType?
+    authorization: LSHTTPAuthorizationType?,
   ): LSHTTPRequestBuilderType {
     this.properties = this.properties.copy(authorization = authorization)
     return this
@@ -81,7 +81,7 @@ class LSHTTPRequestBuilder(
 
   override fun addCookie(
     name: String,
-    value: String
+    value: String,
   ): LSHTTPRequestBuilderType {
     val oldCookies = TreeMap(this.properties.cookies)
     oldCookies[name] = value
@@ -90,7 +90,7 @@ class LSHTTPRequestBuilder(
   }
 
   override fun removeCookie(
-    name: String
+    name: String,
   ): LSHTTPRequestBuilderType {
     val oldCookies = TreeMap(this.properties.cookies)
     oldCookies.remove(name)
@@ -104,7 +104,7 @@ class LSHTTPRequestBuilder(
   }
 
   override fun setRequestModifier(
-    modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties
+    modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties,
   ): LSHTTPRequestBuilderType {
     this.modifier = modifier
     return this
@@ -112,7 +112,7 @@ class LSHTTPRequestBuilder(
 
   override fun setExtensionProperty(
     key: String,
-    value: Any
+    value: Any,
   ): LSHTTPRequestBuilderType {
     val oldProperties = this.properties.otherProperties
     val newItem = key to value
@@ -121,7 +121,7 @@ class LSHTTPRequestBuilder(
   }
 
   override fun setResponseObserver(
-    observer: (LSHTTPResponseType) -> Unit
+    observer: (LSHTTPResponseType) -> Unit,
   ): LSHTTPRequestBuilderType {
     this.observer = observer
     return this
@@ -133,7 +133,7 @@ class LSHTTPRequestBuilder(
       allowRedirects = this.redirects,
       modifier = this.modifier,
       observer = this.observer,
-      properties = this.properties
+      properties = this.properties,
     )
   }
 }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPResponse.kt
@@ -19,7 +19,7 @@ import org.librarysimplified.http.api.LSHTTPResponseType
 
 class LSHTTPResponse(
   override val status: LSHTTPResponseStatus,
-  val response: Response?
+  val response: Response?,
 ) : LSHTTPResponseType {
 
   companion object {
@@ -30,7 +30,7 @@ class LSHTTPResponse(
 
     fun ofOkResponse(
       client: LSHTTPClient,
-      response: Response
+      response: Response,
     ): LSHTTPResponse {
       val request = response.request
       val responseCode = response.code
@@ -47,7 +47,7 @@ class LSHTTPResponse(
           client = client,
           request = request,
           responseContentType = responseContentType,
-          responseBody = responseBody
+          responseBody = responseBody,
         )
 
       val responseStream =
@@ -64,7 +64,7 @@ class LSHTTPResponse(
             "[{}]: problem report changed status {} -> {}",
             request.url,
             responseCode,
-            status
+            status,
           )
           status
         } else {
@@ -86,7 +86,7 @@ class LSHTTPResponse(
           message = responseMessage,
           headers = response.headers.toMultimap(),
           cookies = cookies,
-          authorization = request.tag(LSHTTPRequestProperties::class.java)?.authorization
+          authorization = request.tag(LSHTTPRequestProperties::class.java)?.authorization,
         )
 
       return when {
@@ -94,29 +94,29 @@ class LSHTTPResponse(
           LSHTTPResponse(
             status = LSHTTPResponseStatus.Responded.Error(
               properties = properties,
-              bodyStream = responseStream
+              bodyStream = responseStream,
             ),
-            response = response
+            response = response,
           )
         }
         adjustedStatus >= 300 -> {
           LSHTTPResponse(
             status = LSHTTPResponseStatus.Responded.Error(
               properties = properties.copy(
-                message = refusedRedirectMessage(properties.header("location"))
+                message = refusedRedirectMessage(properties.header("location")),
               ),
-              bodyStream = responseStream
+              bodyStream = responseStream,
             ),
-            response = response
+            response = response,
           )
         }
         else -> {
           LSHTTPResponse(
             status = LSHTTPResponseStatus.Responded.OK(
               properties = properties,
-              bodyStream = responseStream
+              bodyStream = responseStream,
             ),
-            response = response
+            response = response,
           )
         }
       }
@@ -124,16 +124,15 @@ class LSHTTPResponse(
 
     private fun refusedRedirectMessage(location: String?): String {
       return if (location != null) {
-        "Refused to follow a redirect to ${location}."
+        "Refused to follow a redirect to $location."
       } else {
         "Refused to follow a redirect."
       }
     }
 
     private fun lsCookieOf(
-      cookie: Cookie
+      cookie: Cookie,
     ): LSHTTPCookie {
-
       /*
        * Apparently, anything after December 31, 9999 means "does not expire".
        */
@@ -158,8 +157,8 @@ class LSHTTPResponse(
         attributes = mapOf(
           Pair("domain", cookie.domain),
           Pair("hostOnly", cookie.hostOnly.toString()),
-          Pair("persistent", cookie.persistent.toString())
-        )
+          Pair("persistent", cookie.persistent.toString()),
+        ),
       )
     }
 
@@ -167,7 +166,7 @@ class LSHTTPResponse(
       client: LSHTTPClient,
       request: Request,
       responseContentType: MIMEType,
-      responseBody: ResponseBody?
+      responseBody: ResponseBody?,
     ): LSHTTPProblemReport? {
       val responseType = responseContentType.fullType
       val problemType = LSHTTPMimeTypes.problemReport.fullType
@@ -175,7 +174,7 @@ class LSHTTPResponse(
         try {
           client.problemReportParsers.createParser(
             uri = request.url.toString(),
-            stream = responseBody.byteStream()
+            stream = responseBody.byteStream(),
           ).use(LSHTTPProblemReportParserType::execute)
         } catch (e: Exception) {
           null
@@ -187,7 +186,7 @@ class LSHTTPResponse(
 
     private fun parseResponseContentType(
       client: LSHTTPClient,
-      response: Response
+      response: Response,
     ): MIMEType {
       val contentType =
         response.header("content-type") ?: return LSHTTPMimeTypes.octetStream
@@ -196,7 +195,10 @@ class LSHTTPResponse(
         MIMEParser.parseRaisingException(contentType)
       } catch (e: Exception) {
         client.logger.error(
-          "[{}]: could not parse content type: {}: ", response.request.url, contentType, e
+          "[{}]: could not parse content type: {}: ",
+          response.request.url,
+          contentType,
+          e,
         )
         LSHTTPMimeTypes.octetStream
       }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSOKHTTPRequests.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSOKHTTPRequests.kt
@@ -9,7 +9,7 @@ import org.librarysimplified.http.api.LSHTTPRequestProperties
 object LSOKHTTPRequests {
 
   fun createRequest(
-    properties: LSHTTPRequestProperties
+    properties: LSHTTPRequestProperties,
   ): Request {
     val builder = Request.Builder().url(properties.target.toURL())
     return this.createRequestForBuilder(properties, builder)
@@ -17,7 +17,7 @@ object LSOKHTTPRequests {
 
   fun createRequestForBuilder(
     properties: LSHTTPRequestProperties,
-    builder: Request.Builder
+    builder: Request.Builder,
   ): Request {
     val authorization = properties.authorization
     if (authorization != null) {
@@ -30,7 +30,7 @@ object LSOKHTTPRequests {
       val headerText =
         properties.cookies.entries.fold(
           initial = "",
-          operation = { acc, entry -> acc + "${entry.key}=${entry.value};" }
+          operation = { acc, entry -> acc + "${entry.key}=${entry.value};" },
         )
       builder.header("Cookie", headerText)
     }


### PR DESCRIPTION
**What's this do?**
This makes the `http` module produce JDK 11 bytecode instead of JDK 17. This seems necessary until we get all of the projects properly upgraded to use the latest plugins.

**Why are we doing this? (w/ JIRA link if applicable)**
See above!

**How should this be tested? / Do these changes have associated tests?**

**Dependencies for merging? Releasing to production?**

**Have you updated the changelog?**

**Has the application documentation been updated for these changes?**

**Did someone actually run this code to verify it works?**
@io7m Ran a build.