### PR TITLE
Feature/add body to delete method

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -13,9 +13,10 @@
         <c:change date="2022-11-07T00:00:00+00:00" summary="Fixed redirecting bearer token bug."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-08-22T21:13:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
+    <c:release date="2023-09-05T17:00:18+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
       <c:changes>
-        <c:change date="2023-08-22T21:13:39+00:00" summary="Added refresh token interceptor."/>
+        <c:change date="2023-08-22T00:00:00+00:00" summary="Added refresh token interceptor."/>
+        <c:change date="2023-09-05T17:00:18+00:00" summary="Added request body to 'Delete' method."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestBuilderType.kt
+++ b/org.librarysimplified.http.api/src/main/java/org/librarysimplified/http/api/LSHTTPRequestBuilderType.kt
@@ -65,7 +65,11 @@ interface LSHTTPRequestBuilderType {
   sealed class Method {
     object Get : Method()
     object Head : Method()
-    object Delete : Method()
+
+    data class Delete(
+      val body: ByteArray,
+      val contentType: MIMEType,
+    ) : Method()
 
     data class Post(
       val body: ByteArray,

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
@@ -135,7 +135,7 @@ abstract class LSHTTPClientContract {
     val client = clients.create(this.context, this.configuration)
     val request =
       client.newRequest(this.server.url("/xyz").toString())
-        .setMethod(Delete(ByteArray(0), octetStream))
+        .setMethod(Delete("Goodbye!".toByteArray(), LSHTTPMimeTypes.textPlain))
         .build()
 
     request.execute().use { response ->
@@ -145,7 +145,8 @@ abstract class LSHTTPClientContract {
 
     val received = this.server.takeRequest()
     Assertions.assertEquals("DELETE", received.method)
-    Assertions.assertEquals(0, received.bodySize)
+    Assertions.assertEquals(8, received.bodySize)
+    Assertions.assertEquals(LSHTTPMimeTypes.textPlain.fullType, received.getHeader("content-type"))
   }
 
   /**

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/LSHTTPClientContract.kt
@@ -135,7 +135,7 @@ abstract class LSHTTPClientContract {
     val client = clients.create(this.context, this.configuration)
     val request =
       client.newRequest(this.server.url("/xyz").toString())
-        .setMethod(Delete)
+        .setMethod(Delete(ByteArray(0), octetStream))
         .build()
 
     request.execute().use { response ->

--- a/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
+++ b/org.librarysimplified.http.tests/src/test/java/org/librarysimplified/http/tests/bearer_token/LSHTTPBearerTokenContract.kt
@@ -1,6 +1,11 @@
 package org.librarysimplified.http.tests.bearer_token
 
 import android.content.Context
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -18,10 +23,7 @@ import org.librarysimplified.http.api.LSHTTPResponseStatus
 import org.librarysimplified.http.bearer_token.LSHTTPBearerTokenInterceptors
 import org.librarysimplified.http.tests.LSHTTPTestDirectories
 import org.librarysimplified.http.vanilla.LSHTTPProblemReportParsers
-import org.mockito.InOrder
 import org.mockito.Mockito
-import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.OngoingStubbing
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -128,23 +130,6 @@ abstract class LSHTTPBearerTokenContract {
    * updated to reflect it.
    */
 
-  inline fun <reified T : Any> mock2(): T {
-    return Mockito.mock(
-      T::class.java
-    )
-  }
-
-  infix fun <T> OngoingStubbing<T>.doAnswer1(answer: (InvocationOnMock) -> T?): OngoingStubbing<T> {
-    return thenAnswer(answer)
-  }
-
-  inline fun inOrder1(
-    vararg mocks: Any,
-    evaluation: InOrder.() -> Unit
-  ) {
-    Mockito.inOrder(*mocks).evaluation()
-  }
-
   @Test
   fun testPropertiesUpdated() {
     this.server.enqueue(
@@ -172,20 +157,9 @@ abstract class LSHTTPBearerTokenContract {
     val clients = this.clients()
     val client = clients.create(this.context, this.configuration)
 
-    val requestModifier = mock2<(LSHTTPRequestProperties) -> LSHTTPRequestProperties>()
-    Mockito.`when`(requestModifier.invoke(Mockito.any())).doAnswer1 { it.getArgument(0) }
-//    val properties = Mockito.mock(LSHTTPRequestProperties::class.java)
-//    stubbing.thenReturn(stubbing.getArgument(0))
-//    Mockito.`when`(stubbing).thenReturn(stubbing)
-
-//    ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)
-//
-//    var mocks: (LSHTTPRequestProperties) -> LSHTTPRequestProperties =
-//      Mockito.mock<(LSHTTPRequestProperties) -> LSHTTPRequestProperties>()
-//
-//    val requestModifier = mock<(LSHTTPRequestProperties) -> LSHTTPRequestProperties>() {
-//      on { invoke(anyOrNull()) } doAnswer { it.getArgument(0) }
-//    }
+    val requestModifier = mock<(LSHTTPRequestProperties) -> LSHTTPRequestProperties>() {
+      on { invoke(anyOrNull()) } doAnswer { it.getArgument(0) }
+    }
 
     val request =
       client.newRequest(this.server.url("/xyz").toString())
@@ -205,30 +179,16 @@ abstract class LSHTTPBearerTokenContract {
     val sent1 = this.server.takeRequest()
     Assertions.assertEquals("Bearer abcd", sent1.getHeader("Authorization"))
 
-//    inOrder(requestModifier) {
-//      verify(requestModifier).invoke(
-//        argThat {
-//          authorization!!.toHeaderValue() == "Bearer original_token"
-//        },
-//      )
-//
-//      verify(requestModifier).invoke(
-//        argThat {
-//          authorization!!.toHeaderValue() == "Bearer abcd"
-//        },
-//      )
-//    }
-
-    inOrder1(requestModifier) {
-      Mockito.verify(requestModifier).invoke(
-        Mockito.argThat {
-          it.authorization!!.toHeaderValue() == "Bearer original_token"
+    inOrder(requestModifier) {
+      verify(requestModifier).invoke(
+        argThat {
+          authorization!!.toHeaderValue() == "Bearer original_token"
         },
       )
 
-      Mockito.verify(requestModifier).invoke(
-        Mockito.argThat {
-          it.authorization!!.toHeaderValue() == "Bearer abcd"
+      verify(requestModifier).invoke(
+        argThat {
+          authorization!!.toHeaderValue() == "Bearer abcd"
         },
       )
     }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSOKHTTPRequests.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSOKHTTPRequests.kt
@@ -56,8 +56,10 @@ object LSOKHTTPRequests {
         val type = method.contentType.fullType
         builder.put(bytes.toRequestBody(type.toMediaType()))
       }
-      LSHTTPRequestBuilderType.Method.Delete -> {
-        builder.delete()
+      is LSHTTPRequestBuilderType.Method.Delete -> {
+        val bytes = method.body
+        val type = method.contentType.fullType
+        builder.delete(bytes.toRequestBody(type.toMediaType()))
       }
     }
 


### PR DESCRIPTION
**What's this do?**
This PR adds a request body to a Delete method

**Why are we doing this? (w/ JIRA link if applicable)**
There might be some Delete requests that require a some body data

**How should this be tested? / Do these changes have associated tests?**
Future builds of the Palace app will call the Delete method with a request body

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No