### PR TITLE
Fixed redirect request interceptor not being added when there was no properties modifier

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -13,10 +13,11 @@
         <c:change date="2022-11-07T00:00:00+00:00" summary="Fixed redirecting bearer token bug."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-05T17:00:18+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
+    <c:release date="2023-09-13T10:56:37+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
       <c:changes>
         <c:change date="2023-08-22T00:00:00+00:00" summary="Added refresh token interceptor."/>
-        <c:change date="2023-09-05T17:00:18+00:00" summary="Added request body to 'Delete' method."/>
+        <c:change date="2023-09-05T00:00:00+00:00" summary="Added request body to 'Delete' method."/>
+        <c:change date="2023-09-13T10:56:37+00:00" summary="Fixed redirect request interceptor not being added when there was no properties modifier."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPClient.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPClient.kt
@@ -40,13 +40,11 @@ class LSHTTPClient(
   ): OkHttpClient {
     val builder = OkHttpClient.Builder()
 
-    if (modifier != null) {
-      builder.addNetworkInterceptor(LSHTTPRedirectRequestInterceptor(modifier))
-    }
     if (observer != null) {
       builder.addNetworkInterceptor(LSHTTPRedirectResponseInterceptor(this, observer))
     }
 
+    builder.addNetworkInterceptor(LSHTTPRedirectRequestInterceptor(modifier))
     builder.addNetworkInterceptor(LSHTTPLoggingInterceptor(this.logger))
 
     val timeout = this.configuration.timeout

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
@@ -14,21 +14,21 @@ class LSHTTPRedirectRequestInterceptor(
     val request =
       chain.request()
 
-    val properties =
-      request.tag(LSHTTPRequestProperties::class.java)!!
-    val adjProperties =
-      properties.copy(target = request.url.toUri())
-    val newProperties = if (this.modifier != null) {
-      this.modifier.invoke(adjProperties)
+    return if (this.modifier != null) {
+      val properties =
+        request.tag(LSHTTPRequestProperties::class.java)!!
+      val adjProperties =
+        properties.copy(target = request.url.toUri())
+      val newProperties = this.modifier.invoke(adjProperties)
+
+      val requestBuilder =
+        request.newBuilder()
+      val newRequest =
+        LSOKHTTPRequests.createRequestForBuilder(newProperties, requestBuilder)
+
+      chain.proceed(newRequest)
     } else {
-      adjProperties
+      chain.proceed(request)
     }
-
-    val requestBuilder =
-      request.newBuilder()
-    val newRequest =
-      LSOKHTTPRequests.createRequestForBuilder(newProperties, requestBuilder)
-
-    return chain.proceed(newRequest)
   }
 }

--- a/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
+++ b/org.librarysimplified.http.vanilla/src/main/java/org/librarysimplified/http/vanilla/internal/LSHTTPRedirectRequestInterceptor.kt
@@ -5,7 +5,7 @@ import okhttp3.Response
 import org.librarysimplified.http.api.LSHTTPRequestProperties
 
 class LSHTTPRedirectRequestInterceptor(
-  private val modifier: (LSHTTPRequestProperties) -> LSHTTPRequestProperties,
+  private val modifier: ((LSHTTPRequestProperties) -> LSHTTPRequestProperties)?,
 ) : Interceptor {
 
   override fun intercept(
@@ -18,8 +18,11 @@ class LSHTTPRedirectRequestInterceptor(
       request.tag(LSHTTPRequestProperties::class.java)!!
     val adjProperties =
       properties.copy(target = request.url.toUri())
-    val newProperties =
+    val newProperties = if (this.modifier != null) {
       this.modifier.invoke(adjProperties)
+    } else {
+      adjProperties
+    }
 
     val requestBuilder =
       request.newBuilder()


### PR DESCRIPTION
**What's this do?**
This PR updates the LSHTTPClient builder to always add the request interceptor. This also changes the request interceptor `modifier` to be nullable so it just gets called if it's not null.

**Why are we doing this? (w/ JIRA link if applicable)**
When loaning a book from LYRASIS Reads there's a internal redirection that doesn't keep the credentials, which causes the loan to fail.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app and try to get any book from LYRASIS Reads library

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 