### PR TITLE
Fixed refresh token request method

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -13,11 +13,12 @@
         <c:change date="2022-11-07T00:00:00+00:00" summary="Fixed redirecting bearer token bug."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-13T10:56:37+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
+    <c:release date="2023-09-18T18:39:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.2">
       <c:changes>
         <c:change date="2023-08-22T00:00:00+00:00" summary="Added refresh token interceptor."/>
         <c:change date="2023-09-05T00:00:00+00:00" summary="Added request body to 'Delete' method."/>
-        <c:change date="2023-09-13T10:56:37+00:00" summary="Fixed redirect request interceptor not being added when there was no properties modifier."/>
+        <c:change date="2023-09-13T00:00:00+00:00" summary="Fixed redirect request interceptor not being added when there was no properties modifier."/>
+        <c:change date="2023-09-18T18:39:54+00:00" summary="Fixed refresh token request method."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSHTTPBearerTokenInterceptor.kt
+++ b/org.librarysimplified.http.bearer_token/src/main/java/org/librarysimplified/http/bearer_token/internal/LSHTTPBearerTokenInterceptor.kt
@@ -103,7 +103,6 @@ class LSHTTPBearerTokenInterceptor : Interceptor {
 
     val newRequest1 =
       oldRequest.newBuilder()
-        .removeHeader("Authorization")
         .tag(LSHTTPRequestProperties::class.java, request1Properties)
         .url(target)
         .build()

--- a/org.librarysimplified.http.refresh_token/src/main/java/org/librarysimplified/http/refresh_token/internal/LSHTTPRefreshTokenInterceptor.kt
+++ b/org.librarysimplified.http.refresh_token/src/main/java/org/librarysimplified/http/refresh_token/internal/LSHTTPRefreshTokenInterceptor.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.http.refresh_token.internal
 
 import okhttp3.Interceptor
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.librarysimplified.http.api.LSHTTPAuthorizationBasic
 import org.librarysimplified.http.api.LSHTTPAuthorizationBearerToken
@@ -37,7 +38,7 @@ class LSHTTPRefreshTokenInterceptor : Interceptor {
 
       val newRequest = originalRequest
         .newBuilder()
-        .method("POST", null)
+        .method("POST", "".toRequestBody())
         .header(
           "Authorization",
           LSHTTPAuthorizationBasic.ofUsernamePassword(userName, password).toHeaderValue(),

--- a/org.librarysimplified.http.refresh_token/src/main/java/org/librarysimplified/http/refresh_token/internal/LSHTTPRefreshTokenInterceptor.kt
+++ b/org.librarysimplified.http.refresh_token/src/main/java/org/librarysimplified/http/refresh_token/internal/LSHTTPRefreshTokenInterceptor.kt
@@ -37,6 +37,7 @@ class LSHTTPRefreshTokenInterceptor : Interceptor {
 
       val newRequest = originalRequest
         .newBuilder()
+        .method("POST", null)
         .header(
           "Authorization",
           LSHTTPAuthorizationBasic.ofUsernamePassword(userName, password).toHeaderValue(),


### PR DESCRIPTION
**What's this do?**
This PR updates the method of the refreshing token request in the interceptor. This PR also prevents the BearerTokenInterceptor from removing the original auth token after completing its internal operations.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [comment on the auth token ticket](https://ebce-lyrasis.atlassian.net/browse/PP-435?focusedCommentId=11462) saying that we are getting 405 responses from the LYRASIS backend when trying to refresh the auth token.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select LYRASIS Reads library
Try to borrow any book

**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 