### PR TITLE
Fixed wrong downloading percentage values in some books

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -21,8 +21,10 @@
         <c:change date="2023-09-18T00:00:00+00:00" summary="Fixed refresh token request method."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-11T15:39:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.2">
-      <c:changes/>
+    <c:release date="2023-10-24T08:30:37+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.2">
+      <c:changes>
+        <c:change date="2023-10-24T08:30:37+00:00" summary="Fixed wrong downloading percentage values in some books."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-htt
 POM_SCM_URL=http://github.com/ThePalaceProject/android-http
 POM_URL=http://github.com/ThePalaceProject/android-http
 VERSION_NAME=1.2.2-SNAPSHOT
-VERSION_PREVIOUS=1.1.0
+VERSION_PREVIOUS=1.2.1
 
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-htt
 POM_SCM_URL=http://github.com/ThePalaceProject/android-http
 POM_URL=http://github.com/ThePalaceProject/android-http
 VERSION_NAME=1.2.2-SNAPSHOT
-VERSION_PREVIOUS=1.2.1
+VERSION_PREVIOUS=1.1.0
 
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-http
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-http
 POM_SCM_URL=http://github.com/ThePalaceProject/android-http
 POM_URL=http://github.com/ThePalaceProject/android-http
-VERSION_NAME=1.2.2-SNAPSHOT
+VERSION_NAME=1.3.0-SNAPSHOT
 VERSION_PREVIOUS=1.2.1
 
 android.useAndroidX=true

--- a/org.librarysimplified.http.downloads/build.gradle.kts
+++ b/org.librarysimplified.http.downloads/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     implementation(project(":org.librarysimplified.http.api"))
 
+    implementation(libs.commons.compress)
     implementation(libs.irradia.mime.api)
     implementation(libs.jackson.annotations)
     implementation(libs.jackson.core)

--- a/org.librarysimplified.http.tests/build.gradle.kts
+++ b/org.librarysimplified.http.tests/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
         libs.bouncycastle.tls,
         libs.bytebuddy,
         libs.bytebuddy.agent,
+        libs.commons.compress,
         libs.irradia.mime.api,
         libs.irradia.mime.vanilla,
         libs.jackson.annotations,


### PR DESCRIPTION
**What's this do?**
This PR fixes the wrong downloading percentage values in some books by calculating the inputstream's size when it's invalid.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-602) saying there are some books that display wrong values while being downloaded.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Follow [this card](https://ebce-lyrasis.atlassian.net/browse/PP-602)'s reproducing steps
Confirm the values are now being correctly displayed

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/244) also needs to be merged.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 